### PR TITLE
Add int64 json support

### DIFF
--- a/pkg/util/json.go
+++ b/pkg/util/json.go
@@ -134,6 +134,8 @@ func ValueFromJSON(v interface{}) (starlark.Value, error) {
 		return starlark.String(t), nil
 	case float64:
 		return starlark.Float(t), nil
+	case int64:
+		return starlark.MakeInt64(t), nil
 	case bool:
 		return starlark.Bool(t), nil
 	case json.Number:


### PR DESCRIPTION
Without this, doing something like:

```
kube.get(
    deployment="kube-system/kube-dns",
    api_group="extensions",
    json=True,
)
```

fails with `unsupported JSON data type: int64`.