### PR TITLE
Enable testing MutatingWebhookConfigurations

### DIFF
--- a/pkg/kube/kube_fake.go
+++ b/pkg/kube/kube_fake.go
@@ -381,6 +381,7 @@ func fakeDiscovery() discovery.DiscoveryInterface {
 			GroupVersion: admissionregistrationv1b1.SchemeGroupVersion.String(),
 			APIResources: []metav1.APIResource{
 				{Name: "validatingwebhookconfigurations", Kind: "ValidatingWebhookConfiguration"},
+				{Name: "mutatingwebhookconfigurations", Kind: "MutatingWebhookConfiguration"},
 			},
 		},
 	}


### PR DESCRIPTION
Adds MutatingWebhookConfigurations to kube-fake to enable testing of these resources.

Signed-off-by: dustin-decker <dustin.decker@getcruise.com>