### PR TITLE
Improve Vault dry run and fake

### DIFF
--- a/pkg/runtime/options.go
+++ b/pkg/runtime/options.go
@@ -71,7 +71,10 @@ func WithNoSpin() Option {
 // WithVault returns an Option that enables "vault" package.
 func WithVault(c *vapi.Client) Option {
 	return fnOption(func(opts *options) error {
-		opts.pkgs["vault"] = vault.New(c, opts.dryRun)
+		opts.pkgs["vault"] = vault.New(c)
+		if opts.dryRun {
+			opts.pkgs["vault"], _, _ = vault.NewFake()
+		}
 		return nil
 	})
 }

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"net/http"
 
-	log "github.com/golang/glog"
 	vault "github.com/hashicorp/vault/api"
 	"go.starlark.net/starlark"
 
@@ -35,14 +34,12 @@ import (
 type vaultPackage struct {
 	*isopod.Module
 	client *vault.Client
-	dryRun bool
 }
 
 // New returns a new skaylark.HasAttrs object for vault package.
-func New(c *vault.Client, dryRun bool) *isopod.Module {
+func New(c *vault.Client) *isopod.Module {
 	v := &vaultPackage{
 		client: c,
-		dryRun: dryRun,
 	}
 	v.Module = &isopod.Module{
 		Name: "vault",
@@ -156,13 +153,7 @@ func (p *vaultPackage) vaultWriteFn(t *starlark.Thread, b *starlark.Builtin, arg
 
 	r := p.client.NewRequest("PUT", "/v1/"+path)
 	if err := r.SetJSONBody(data); err != nil {
-		return nil, fmt.Errorf("failed to set request body to %v: %v", data, err)
-	}
-
-	if p.dryRun {
-		r.ClientToken = "redacted"
-		log.V(1).Infof("<%v>: dry run: %v", b.Name(), r)
-		return starlark.None, nil
+		return nil, fmt.Errorf("failed to set request body to %+v: %v", data, err)
 	}
 
 	ctx := t.Local(addon.GoCtxKey).(context.Context)

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -1,135 +1,49 @@
-// Copyright 2019 GM Cruise LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package vault
 
 import (
-	"encoding/json"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"go.starlark.net/starlark"
 
 	util "github.com/cruise-automation/isopod/pkg/testing"
 )
 
-// fakeServer creates fake Vault endpoint.
-func fakeServer(t *testing.T, wantValues map[string]string, rawData string) *httptest.Server {
-	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/foo/bar" {
-			http.Error(w, "not found", http.StatusNotFound)
-			t.Errorf("unexpected path: %s", r.URL.Path)
-			return
-		}
-		switch r.Method {
-		case http.MethodGet:
-			m := json.RawMessage(rawData)
-			b, err := m.MarshalJSON()
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				t.Error(err)
-				return
-			}
-
-			if _, err := w.Write(b); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				t.Error(err)
-				return
-			}
-		case http.MethodPut:
-			bs, err := json.Marshal(wantValues)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				t.Error(err)
-				return
-			}
-			wantValues := string(bs)
-
-			bs, err = ioutil.ReadAll(r.Body)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				t.Error(err)
-				return
-			}
-			gotValues := string(bs)
-
-			if d := cmp.Diff(wantValues, gotValues); d != "" {
-				http.Error(w, "unexpected values", http.StatusBadRequest)
-				t.Errorf("Unexpected values written: (-want +got)\n%s", d)
-			}
-		default:
-			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
-			t.Errorf("Unexpected method: %v", r.Method)
-		}
-	}))
-}
-
 func TestVault(t *testing.T) {
+	tv, closeFn, err := NewFake()
+	defer closeFn()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, tc := range []struct {
-		desc    string
-		expr    string
-		rawData string
-		dryRun  bool
+		desc string
+		expr string
 
 		wantResult string
-		wantValues map[string]string
 		wantErr    string
 	}{
-		{
-			desc:       "Read secret from `foo/bar'",
-			expr:       "vault.read('foo/bar')",
-			rawData:    `{"data": {"a": "b", "c": 1, "d": false, "e": [1, 2, 3], "f": null}}`,
-			wantResult: `map["a":"b" "c":1 "d":False "e":[1, 2, 3] "f":None]`,
-		},
-		{
-			desc:       "Read raw data from `foo/bar'",
-			expr:       "vault.read_raw('foo/bar')",
-			rawData:    `{"a": {"b": "c"}}`,
-			wantResult: `map["a":map["b":"c"]]`,
-		},
 		{
 			desc:       "Write value to `foo/bar'",
 			expr:       "vault.write('foo/bar', a='1', b='2')",
 			wantResult: "None",
-			wantValues: map[string]string{"a": "1", "b": "2"},
 		},
 		{
-			desc:       "Dry run write",
-			expr:       "vault.write('foo/bar', a='1', b='2')",
-			dryRun:     true,
-			wantResult: "None",
-			wantValues: map[string]string{},
+			desc:       "Read raw data from `foo/bar'",
+			expr:       "vault.read_raw('foo/bar')",
+			wantResult: `map["data":map["a":"1" "b":"2"]]`,
 		},
 		{
 			desc:       "Check if `foo/bar' exists",
 			expr:       "vault.exist('foo/bar')",
 			wantResult: "True",
 		},
+		{
+			desc:       "Read data from `foo/bar'",
+			expr:       "vault.read('foo/bar')",
+			wantResult: `map["a":"1" "b":"2"]`,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			ts := fakeServer(t, tc.wantValues, tc.rawData)
-			defer ts.Close()
-
-			tv, err := NewFakeWithServer(ts, tc.dryRun)
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			pkgs := starlark.StringDict{"vault": tv}
 			v, _, err := util.Eval(t.Name(), tc.expr, nil, pkgs)
 


### PR DESCRIPTION
- Uses Vault fake for dry runs
- Fall back to real Vault contents if fake key does not exist
- Adds PKI backend support for certificate issuance to vault_fake
- Uses Vault fake for unit tests. It had some other fake before.

Signed-off-by: dustin-decker <dustin.decker@getcruise.com>