### PR TITLE
auth with private master endpoint if existed

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ extended to cover other Kubernetes vendors, such as EKS and AKS.
 
 #### `gke()`
 
-Represents a Google Kubernetes Engine. Authenticates using Google Cloud Service Account Credentials or Google Default Application Credentials. Requires the `cluster`, `location`, and `project` fields. Additional fields are allowed.
+Represents a Google Kubernetes Engine. Authenticates using Google Cloud Service Account Credentials or Google Default Application Credentials. Requires the `cluster`, `location` and `project` fields, while optionally takes `use_internal_ip` field to connect API server via private endpoint. Additional fields are allowed.
 
 #### `onprem()`
 
@@ -133,6 +133,7 @@ gke(
     cluster="paas-prod",
     location="us-west1",
     project="cruise-paas-prod",
+    # use_internal_ip="true", # (optional, default use public endpoint)
 ),
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ CLUSTERS = [
         cluster="paas-prod",
         location="us-west1",
         project="cruise-paas-prod",
+        # use_internal_ip="true", # (optional, default use public endpoint)
     ),
 ]
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ CLUSTERS = [
         cluster="paas-prod",
         location="us-west1",
         project="cruise-paas-prod",
-        # use_internal_ip="true", # (optional, default use public endpoint)
+        use_internal_ip="false", # default to "false", which uses public endpoint
     ),
 ]
 
@@ -134,7 +134,7 @@ gke(
     cluster="paas-prod",
     location="us-west1",
     project="cruise-paas-prod",
-    # use_internal_ip="true", # (optional, default use public endpoint)
+    use_internal_ip="false", # default to "false", which uses public endpoint
 ),
 ```
 

--- a/pkg/cloud/gke/auth.go
+++ b/pkg/cloud/gke/auth.go
@@ -90,8 +90,12 @@ func buildKubeRestConf(
 	if err != nil {
 		return nil, fmt.Errorf("failed to base64 decode the cluster CA cert: %v", err)
 	}
+	endpoint := cluster.Endpoint
+	if cluster.PrivateClusterConfig != nil && cluster.PrivateClusterConfig.PrivateEndpoint != "" {
+		endpoint = cluster.PrivateClusterConfig.PrivateEndpoint
+	}
 	return &rest.Config{
-		Host: "https://" + cluster.Endpoint,
+		Host: "https://" + endpoint,
 		TLSClientConfig: rest.TLSClientConfig{
 			CAData: caCert, // pem encoded
 		},

--- a/pkg/cloud/gke/auth.go
+++ b/pkg/cloud/gke/auth.go
@@ -45,34 +45,34 @@ func GoogleCredTokenSourceFromSAKey(ctx context.Context, svcAcctKeyFile string) 
 // key file. If such key is empty, fall back to using default application cred.
 func BuildKubeRestConfSACred(
 	ctx context.Context,
-	clusterName, location, project, svcAcctKeyFile, userAgent string,
+	clusterName, location, project, useInternalIP, svcAcctKeyFile, userAgent string,
 ) (*rest.Config, error) {
 	if svcAcctKeyFile == "" {
-		return BuildKubeRestConfDefaultCred(ctx, clusterName, location, project, userAgent)
+		return BuildKubeRestConfDefaultCred(ctx, clusterName, location, project, useInternalIP, userAgent)
 	}
 	TokenSrc, err := GoogleCredTokenSourceFromSAKey(ctx, svcAcctKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get token source from service account: %v", err)
 	}
-	return buildKubeRestConf(ctx, clusterName, location, project, userAgent, TokenSrc)
+	return buildKubeRestConf(ctx, clusterName, location, project, useInternalIP, userAgent, TokenSrc)
 }
 
 // BuildKubeRestConfDefaultCred creates a k8s rest.Config using the google
 // application default credential.
 func BuildKubeRestConfDefaultCred(
 	ctx context.Context,
-	clusterName, location, project, userAgent string,
+	clusterName, location, project, useInternalIP, userAgent string,
 ) (*rest.Config, error) {
 	tokenSrc, err := google.DefaultTokenSource(ctx, container.CloudPlatformScope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the google DefaultTokenSource: %v", err)
 	}
-	return buildKubeRestConf(ctx, clusterName, location, project, userAgent, tokenSrc)
+	return buildKubeRestConf(ctx, clusterName, location, project, useInternalIP, userAgent, tokenSrc)
 }
 
 func buildKubeRestConf(
 	ctx context.Context,
-	clusterName, location, project, userAgent string,
+	clusterName, location, project, useInternalIP, userAgent string,
 	tokenSrc oauth2.TokenSource,
 ) (*rest.Config, error) {
 	containerSvc, err := container.NewService(ctx, option.WithTokenSource(tokenSrc))
@@ -90,9 +90,13 @@ func buildKubeRestConf(
 	if err != nil {
 		return nil, fmt.Errorf("failed to base64 decode the cluster CA cert: %v", err)
 	}
+
+	// determine which endpoint to use to connect to API server on master
 	endpoint := cluster.Endpoint
-	if cluster.PrivateClusterConfig != nil && cluster.PrivateClusterConfig.PrivateEndpoint != "" {
-		endpoint = cluster.PrivateClusterConfig.PrivateEndpoint
+	if useInternalIP == "true" {
+		if cluster.PrivateClusterConfig != nil && cluster.PrivateClusterConfig.PrivateEndpoint != "" {
+			endpoint = cluster.PrivateClusterConfig.PrivateEndpoint
+		}
 	}
 	return &rest.Config{
 		Host: "https://" + endpoint,

--- a/pkg/cloud/gke/gke.go
+++ b/pkg/cloud/gke/gke.go
@@ -33,6 +33,8 @@ const (
 	ProjectKey = "project"
 	// LocationKey is the name of the location field.
 	LocationKey = "location"
+	// UseInternalIPKey indicates if connecting API server via private endpoint
+	UseInternalIPKey = "use_internal_ip"
 )
 
 var (
@@ -72,11 +74,11 @@ func NewGKEBuiltin(svcAcctKeyFile, userAgent string) *starlark.Builtin {
 
 // KubeConfig is part of the cloud.KubernetesVendor interface.
 func (g *GKE) KubeConfig(ctx context.Context) (*rest.Config, error) {
-	cluster, location, project, err := clpFromClusterCtx(g.SkyCtx)
+	cluster, location, project, useInternalIP, err := clpFromClusterCtx(g.SkyCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract cluster info from %v: %v", g, err)
 	}
-	return BuildKubeRestConfSACred(ctx, cluster, location, project, g.svcAcctKeyFile, g.userAgent)
+	return BuildKubeRestConfSACred(ctx, cluster, location, project, useInternalIP, g.svcAcctKeyFile, g.userAgent)
 }
 
 func stringFromValue(v starlark.Value) (string, error) {
@@ -90,13 +92,16 @@ func stringFromValue(v starlark.Value) (string, error) {
 	return string(s), nil
 }
 
-func clpFromClusterCtx(c *addon.SkyCtx) (cluster, location, project string, err error) {
+func clpFromClusterCtx(c *addon.SkyCtx) (cluster, location, project, useInternalIP string, err error) {
 	if cluster, err = stringFromValue(c.Attrs[ClusterKey]); err != nil {
 		return
 	}
 	if location, err = stringFromValue(c.Attrs[LocationKey]); err != nil {
 		return
 	}
-	project, err = stringFromValue(c.Attrs[ProjectKey])
+	if project, err = stringFromValue(c.Attrs[ProjectKey]); err != nil {
+		return
+	}
+	useInternalIP, _ = stringFromValue(c.Attrs[UseInternalIPKey])
 	return
 }

--- a/pkg/cloud/gke/gke.go
+++ b/pkg/cloud/gke/gke.go
@@ -102,6 +102,10 @@ func clpFromClusterCtx(c *addon.SkyCtx) (cluster, location, project, useInternal
 	if project, err = stringFromValue(c.Attrs[ProjectKey]); err != nil {
 		return
 	}
-	useInternalIP, _ = stringFromValue(c.Attrs[UseInternalIPKey])
+	if val := c.Attrs[UseInternalIPKey]; val != nil {
+		if v, ok := val.(starlark.String); ok {
+			useInternalIP = string(v)
+		}
+	}
 	return
 }


### PR DESCRIPTION
verified it's working for both regular cluster and only private network cluster
```
./install.sh -c cluster=paas-ci-us-central1-4
cluster.Endpoint 10.212.1.178
Beginning rollout [rollout-bnkktobo6hijflfj2aag] installation...
...
Rollout [rollout-bnkktobo6hijflfj2aag] is live!
```

```
/install.sh -c cluster=paas-dev-us-central1 --dry_run -m rbacsync
Beginning rollout [rollout-bnknk6jo6hinkp3kpei0] installation...
I1205 13:43:55.155076   31332 properties.go:196] proto: tag has too few fields: "-"

*** secret.v1 `secret.v1 `kube-system/rbacsync-gsuite-credentials'' ***
--- live
+++ head
@@ -5,10 +5,10 @@
```