### PR TITLE
Add file addon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,3 +124,5 @@ require (
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 	sigs.k8s.io/yaml v1.1.0
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,7 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stripe/skycfg v0.0.0-20190805025019-bafbc3998017 h1:QF2hQ30rLdDMk6oB4ezDZ7GKiu7iL7ulyg7BT0VvjL8=
 github.com/stripe/skycfg v0.0.0-20190805025019-bafbc3998017/go.mod h1:nc0qou0URq+8vaEcIz0O6ZD9DgYdLiwYRWWyB2LwSAU=
+github.com/stripe/skycfg v0.0.0-20191220035312-c3022a7eb23f h1:mJxyjbJSqj55Y8Th3gKjh6U0QS+MgjLy/6m1hhUFiyI=
 github.com/tj/go-spin v1.1.0 h1:lhdWZsvImxvZ3q1C5OIB7d72DuOwP4O2NdBg9PyzNds=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 h1:G3dpKMzFDjgEh2q1Z7zUUtKa8ViPtH+ocF0bE0g00O8=

--- a/main.go
+++ b/main.go
@@ -134,6 +134,7 @@ func buildAddonsRuntime(kubeC *rest.Config, mainFile string) (runtime.Runtime, e
 		runtime.WithKube(kubeC, *kubeDiff),
 		runtime.WithHelm(helmBaseDir),
 		runtime.WithAddonRegex(regexp.MustCompile(*addonRegex)),
+		runtime.WithFile(),
 	}
 	if *noSpin {
 		opts = append(opts, runtime.WithNoSpin())

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -1,0 +1,43 @@
+package file
+
+import (
+	"io/ioutil"
+
+	isopod "github.com/cruise-automation/isopod/pkg"
+	"go.starlark.net/starlark"
+)
+
+type filePackage struct {
+	*isopod.Module
+}
+
+// New returns a new starlark.HasAttrs object for file package.
+func New() starlark.HasAttrs {
+	f := &filePackage{}
+
+	f.Module = &isopod.Module{
+		Name: "file",
+		Attrs: starlark.StringDict{
+			"read": starlark.NewBuiltin("file.read", f.readFile),
+		},
+	}
+
+	return f
+}
+
+// readFile blindly reads a file and returns it as a string
+func (f *filePackage) readFile(t *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var filename string
+	unpacked := []interface{}{
+		"filename", &filename,
+	}
+
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, unpacked...); err != nil {
+		return nil, err
+	}
+	dat, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return starlark.String(dat), nil
+}

--- a/pkg/runtime/options.go
+++ b/pkg/runtime/options.go
@@ -38,6 +38,7 @@ import (
 	// Plugin imports for auth.
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
+	fileaddon "github.com/cruise-automation/isopod/pkg/file"
 	"github.com/cruise-automation/isopod/pkg/helm"
 	"github.com/cruise-automation/isopod/pkg/kube"
 	"github.com/cruise-automation/isopod/pkg/vault"
@@ -154,6 +155,13 @@ func WithHelm(baseDir string) Option {
 func WithAddonRegex(r *regexp.Regexp) Option {
 	return fnOption(func(opts *options) error {
 		opts.addonRe = r
+		return nil
+	})
+}
+
+func WithFile() Option {
+	return fnOption(func(opts *options) error {
+		opts.pkgs["file"] = fileaddon.New()
 		return nil
 	})
 }


### PR DESCRIPTION
This adds an addon called `file` that allows you to read an arbitrary file. This is certainly _not_ hermetic, but i figure that hermeticity went out the window a long time ago since we do API requests and whatnot.

Example:
```starlark
someValues = yaml.unmarshal(file.read('/abs/path/to/some/file.yaml'))
```

It's sort of a bummer that this doesn't happen during the loading phase, but I don't know how to change that.