### PR TITLE
Support writing list values in vault.write

### DIFF
--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -42,6 +42,11 @@ func TestVault(t *testing.T) {
 			wantResult: "None",
 		},
 		{
+			desc:       "Write list value to `foo/bar2'",
+			expr:       "vault.write('foo/bar2', a=['1','2'], b='2')",
+			wantResult: "None",
+		},
+		{
 			desc:       "Read raw data from `foo/bar'",
 			expr:       "vault.read_raw('foo/bar')",
 			wantResult: `map["data":map["a":"1" "b":"2"]]`,

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -61,6 +61,11 @@ func TestVault(t *testing.T) {
 			expr:       "vault.read('foo/bar')",
 			wantResult: `map["a":"1" "b":"2"]`,
 		},
+		{
+			desc:       "Read data from `foo/bar2'",
+			expr:       "vault.read('foo/bar2')",
+			wantResult: `map["a":["1", "2"] "b":"2"]`,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			pkgs := starlark.StringDict{"vault": tv}


### PR DESCRIPTION
With some `vault.write()` requests we need to write lists for the values of keyword arguments.

For example, such as with [CSR roles](https://www.vaultproject.io/api-docs/secret/pki/#parameters-8).

```
vault.write(pki/roles/example-dot-com, allowed_domains="my-website.com",
    allow_subdomains="true", max_ttl="72h",
    key_usage=["DigitalSignature", "KeyAgreement", "KeyEncipherment"])
```