### PR TITLE
adding vault kubeconfig for onprem

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Example:
 
 ```python
 CLUSTERS = [
-    onprem(env="dev", cluster="minikube"),
+    onprem(env="dev", cluster="minikube", vaultkubeconfig="secret/path"),
     gke(
         env="prod",
         cluster="paas-prod",
@@ -121,7 +121,7 @@ Represents a Google Kubernetes Engine. Authenticates using Google Cloud Service 
 
 #### `onprem()`
 
-Represents an on-premise or self-managed Kubernetes cluster. Authenticates using the `kubeconfig` file. No fields are required.
+Represents an on-premise or self-managed Kubernetes cluster. Authenticates using the `kubeconfig` file or Vault path containing the `kubeconfig`. No fields are required, though setting the `vaultkubeconfig` field to the path in Vault where the KubeConfig exists is necessary to utilize this auth method.
 
 
 ## Addons

--- a/pkg/cloud/onprem/onprem_test.go
+++ b/pkg/cloud/onprem/onprem_test.go
@@ -39,6 +39,11 @@ func TestOnPremBuiltin(t *testing.T) {
 			expr:    `onprem(cluster="minikube", env="dev").env`,
 			wantVal: starlark.String("dev"),
 		},
+		{
+			name:    "reference vaultkubeconfig field",
+			expr:    `onprem(cluster="test", env="dev", vaultkubeconfig="secret/test").vaultkubeconfig`,
+			wantVal: starlark.String("secret/test"),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			pkgs := starlark.StringDict{"onprem": NewOnPremBuiltin("some-kubeconfig-file")}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -372,6 +372,9 @@ func (r *runtime) ForEachCluster(ctx context.Context, userCtx map[string]string,
 			continue
 		}
 
+		clusterName := k8sVendor.AddonSkyCtx(userCtx).Attrs["cluster"]
+		fmt.Printf("Current cluster: (%s)\n", clusterName)
+
 		fn(k8sVendor)
 	}
 	return nil

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -220,3 +220,24 @@ func (p *vaultPackage) vaultExistFn(t *starlark.Thread, b *starlark.Builtin, arg
 
 	return starlark.True, nil
 }
+
+// ReadVaultPath takes in the Vault path and returns the value as a string.
+// Must have VAULT_ADDR set, and vault token is grabbed from flags.
+func ReadVaultPath(path string) (string, error) {
+	client, err := vault.NewClient(nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to initialize Vault client: %v", err)
+	}
+	c := client.Logical()
+
+	secret, err := c.Read(path)
+	if err != nil {
+		return "", err
+	}
+	if secret == nil {
+		return "", fmt.Errorf("vault secret contains no value")
+	}
+
+	data := secret.Data["value"]
+	return fmt.Sprint(data), nil
+}


### PR DESCRIPTION
Adding the ability to use kubeconfigs that exist in vault. This allows the onprem type to not just use local kubeconfigs.

Also adding a cluster name output so that we can see which cluster is getting changes applied.

cc @cxuu 