### PR TITLE
Add pre-commit config and fix linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+exclude: "^vendor/.*"
+repos:
+- repo: https://github.com/syntaqx/git-hooks
+  rev: v0.0.16
+  hooks:
+    - id: circleci-config-validate
+    - id: go-fmt
+- repo: git://github.com/PyCQA/pylint
+  rev: pylint-2.4.4
+  hooks:
+    - id: pylint
+      types: [file]  # Overrides types: [python]
+      files: \.(star|ipd)$
+- repo: git://github.com/pre-commit/pre-commit-hooks
+  rev: v2.5.0
+  hooks:
+    - id: trailing-whitespace

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,34 @@
+[MASTER]
+
+disable=
+    missing-docstring,
+    undefined-variable,
+    assert-on-tuple,
+    invalid-name,
+    len-as-condition,
+    unused-argument,
+    duplicate-code,
+    no-member,
+    syntax-error,
+    fixme,
+    redefined-outer-name,
+    too-many-locals,
+    redefined-builtin,
+    too-many-arguments,
+    dangerous-default-value,
+    singleton-comparison,
+    superfluous-parens,
+    misplaced-comparison-constant,
+    anomalous-backslash-in-string,
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Maximum number of lines in a single file.
+max-module-lines=2000

--- a/go.mod
+++ b/go.mod
@@ -124,3 +124,5 @@ require (
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 	sigs.k8s.io/yaml v1.1.0
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,7 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stripe/skycfg v0.0.0-20190805025019-bafbc3998017 h1:QF2hQ30rLdDMk6oB4ezDZ7GKiu7iL7ulyg7BT0VvjL8=
 github.com/stripe/skycfg v0.0.0-20190805025019-bafbc3998017/go.mod h1:nc0qou0URq+8vaEcIz0O6ZD9DgYdLiwYRWWyB2LwSAU=
+github.com/stripe/skycfg v0.0.0-20200303020846-4f599970a3e6 h1:Nr78kwzRyXZaimz7tFFlJcc5mO2rMecmP/eiCPHDeqE=
 github.com/tj/go-spin v1.1.0 h1:lhdWZsvImxvZ3q1C5OIB7d72DuOwP4O2NdBg9PyzNds=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 h1:G3dpKMzFDjgEh2q1Z7zUUtKa8ViPtH+ocF0bE0g00O8=

--- a/testdata/addon.ipd
+++ b/testdata/addon.ipd
@@ -16,16 +16,16 @@
 
 
 def match(ctx):
-  print("match")
-  return True
+    print("match")
+    return True
 
 def status(ctx):
-  return ctx.cluster + " status"
+    return ctx.cluster + " status"
 
 def install(ctx):
-  if ctx.snafoo != None:
-    error("Non-existent context is not `None': {ctx}".format(ctx=ctx.snafoo))
-  print("install " + ctx.cluster)
+    if ctx.snafoo != None:
+        error("Non-existent context is not `None': {ctx}".format(ctx=ctx.snafoo))
+    print("install " + ctx.cluster)
 
 def remove(ctx):
-  print("remove " + ctx.cluster)
+    print("remove " + ctx.cluster)

--- a/testdata/ingress.ipd
+++ b/testdata/ingress.ipd
@@ -20,14 +20,15 @@ metav1 = proto.package("k8s.io.apimachinery.pkg.apis.meta.v1")
 
 
 def install(ctx):
-  print("Installing ingress for cluster={cluster}...".format(cluster=ctx.cluster))
+    print("Installing ingress for cluster={cluster}...".format(cluster=ctx.cluster))
 
-  data = vault.read("secret/car/cert")
+    data = vault.read("secret/car/cert")
 
-  kube.put(
-    name = ctx.namespace,
-    data = [
-        corev1.Namespace(metadata=metav1.ObjectMeta(labels={"foo": "bar"})),
-    ])
+    kube.put(
+        name=ctx.namespace,
+        data=[
+            corev1.Namespace(metadata=metav1.ObjectMeta(labels={"foo": "bar"})),
+        ],
+    )
 
-  print("{a}".format(a=data["crt"]))
+    print("{a}".format(a=data["crt"]))

--- a/testdata/istio/helm.ipd
+++ b/testdata/istio/helm.ipd
@@ -17,11 +17,11 @@
 def install(ctx):
     print('Installing helm chart for cluster={cluster}...'.format(cluster=ctx.cluster))
 
-    globalValues="""
+    globalValues = """
 global:
     priorityClassName: "cluster-critical"
 """
-    pilotValues="""
+    pilotValues = """
 pilot:
     replicaCount: 3
     image: "docker.io/istio/pilot:v1.2.3"

--- a/testdata/main.ipd
+++ b/testdata/main.ipd
@@ -20,7 +20,7 @@ load("clusters.star", "CLUSTERS")
 def clusters(ctx):
     if ctx.cluster != None:
         return [c for c in CLUSTERS if c.cluster == ctx.cluster]
-    elif ctx.env != None:
+    if ctx.env != None:
         return [c for c in CLUSTERS if c.env == ctx.env]
     return CLUSTERS
 

--- a/testdata/values.star
+++ b/testdata/values.star
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-moreValues="""
+moreValues = """
 global:
     configNamespace: istio-pilot
 """
 
-globalValues="""
+globalValues = """
 global:
     priorityClassName: "cluster-critical",
 """


### PR DESCRIPTION
This adds [pre-commit](https://pre-commit.com/) to run some menial linting tasks.

The way this works is that you just run:
```bash
pip install pre-commit  # Just do this once on your machine
pre-commit install  # Do this after cloning for each repo
```

And then when you commit files, it will run the pre-commit checks against the changed files.

I went ahead and ran these hooks against all of the files and fixed the issues, so there should be no false positives going forward.