### PR TITLE
runtime: do not create a rollout for dryrun

### DIFF
--- a/pkg/kube/diff.go
+++ b/pkg/kube/diff.go
@@ -117,6 +117,9 @@ func renderObj(obj runtime.Object, gvk *schema.GroupVersionKind, renderYaml bool
 // * Kubernetes namespace finalizer on live and head objects.
 // * Master-assigned ServiceAccount token secret in the live ServiceAccount.
 func removeSpuriousDiff(live, head runtime.Object) (newLive, newHead runtime.Object) {
+	if live == nil || head == nil {
+		return live, head
+	}
 	newLive, newHead = live.DeepCopyObject(), head.DeepCopyObject()
 	removeSpuriousNodePortDiff(newLive, newHead)
 	removeSpuriousNamespaceFinalizerDiff(newLive, newHead)


### PR DESCRIPTION
and a bug fix where the following cases will result in nil pointer dereference
* deploying a new k8s object for the first time (live is nil)
* removing a k8s object (head is nil)