### PR TITLE
diff: clean resource name

### DIFF
--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -672,13 +672,13 @@ func (m *kubePackage) kubeUpdate(ctx context.Context, r *apiResource, msg proto.
 	}
 
 	if m.diff {
-		if err := printUnifiedDiff(os.Stdout, live, msg.(runtime.Object), r.GVK, r.String(), m.diffFilters); err != nil {
+		if err := printUnifiedDiff(os.Stdout, live, msg.(runtime.Object), r.GVK, maybeNamespaced(r.Name, r.Namespace), m.diffFilters); err != nil {
 			return err
 		}
 	}
 
 	if m.dryRun {
-		return printUnifiedDiff(os.Stdout, live, msg.(runtime.Object), r.GVK, r.String(), m.diffFilters)
+		return printUnifiedDiff(os.Stdout, live, msg.(runtime.Object), r.GVK, maybeNamespaced(r.Name, r.Namespace), m.diffFilters)
 	}
 
 	resp, err := m.httpClient.Do(req.WithContext(ctx))


### PR DESCRIPTION
Without this fix, the dry run diff output looks like 
```
*** namespace.v1 `namespace.v1 `ingress'' ***
```

but we want 

```
*** namespace.v1 `ingress' ***
```

This issue currently only exist for `kube.put()`. `kube.put_yaml()` and `helm.apply()` works fine