### PR TITLE
diff: filter log spam in dryrun

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	stdlog "log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -163,11 +164,18 @@ func buildAddonsRuntime(kubeC *rest.Config, mainFile string) (runtime.Runtime, e
 	return addons, nil
 }
 
+type verboseGlogWriter struct{}
+
+func (w *verboseGlogWriter) Write(p []byte) (n int, err error) {
+	log.V(1).Info(string(p))
+	return len(p), nil
+}
+
 func main() {
 	ctx := context.Background()
 
-	// Redirects all output to standrad Go log to Google's log.
-	log.CopyStandardLogTo("INFO")
+	// Redirects all output to standrad Go log to Google's log at verbose level 1.
+	stdlog.SetOutput(&verboseGlogWriter{})
 	defer log.Flush()
 
 	if *showVersion {

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ var (
 
 func init() {
 	flag.Parse()
+	stdlog.SetFlags(stdlog.Lshortfile)
 }
 
 func usageAndDie() {

--- a/pkg/kpath/kpath.go
+++ b/pkg/kpath/kpath.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kpath
 
 import (

--- a/pkg/kpath/kpath_test.go
+++ b/pkg/kpath/kpath_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kpath
 
 import (

--- a/pkg/kube/filter.go
+++ b/pkg/kube/filter.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kube
 
 import (

--- a/pkg/modules/base64.go
+++ b/pkg/modules/base64.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package modules
 
 import (

--- a/pkg/modules/base64_test.go
+++ b/pkg/modules/base64_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package modules
 
 import (

--- a/pkg/modules/dict.go
+++ b/pkg/modules/dict.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package modules
 
 import (

--- a/pkg/modules/http_test.go
+++ b/pkg/modules/http_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package modules
 
 import (

--- a/pkg/modules/struct_test.go
+++ b/pkg/modules/struct_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package modules
 
 import (

--- a/pkg/modules/uuid.go
+++ b/pkg/modules/uuid.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package modules
 
 import (

--- a/pkg/modules/uuid_test.go
+++ b/pkg/modules/uuid_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package modules
 
 import (

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -15,10 +15,11 @@
 package runtime
 
 import (
-	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
+	golog "log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -155,31 +156,20 @@ func (r *runtime) Load(ctx context.Context) error {
 	return nil
 }
 
-type runStatus struct {
-	err    error
-	msgs   []string
-	doneCh chan struct{}
-}
-
-// spinMsg prints spinner while waiting on doneCh to return status, then exits.
-// Closes doneCh on exit.
-func spinMsg(addonName string, doneCh chan *runStatus) {
+// spinMsg prints spinner while waiting on errCh to return error, then exits.
+func spinMsg(addonName string, errCh chan error) {
 	s := spin.New()
 	s.Set(spin.Spin1)
 	for {
 		select {
 		case <-time.After(100 * time.Millisecond):
 			fmt.Printf("\r Installing %s... %s", addonName, s.Next())
-		case s := <-doneCh:
-			defer close(s.doneCh)
-
-			if s.err != nil {
-				fmt.Printf("\r Installing %s... err: %v\n", addonName, s.err)
+		case err := <-errCh:
+			if err != nil {
+				fmt.Printf("\r Installing %s... err: %v\n", addonName, err)
 			} else {
 				fmt.Printf("\r Installing %s... done\n", addonName)
 			}
-			fmt.Printf("\t%s\n", strings.Join(s.msgs, "\n\t"))
-
 			return
 		}
 	}
@@ -203,42 +193,64 @@ func (r *runtime) runCommand(ctx context.Context, cmd Command, addons []*addon.A
 		}
 		// TODO(dmitry-ilyevskiy): Print "live" status.
 		fmt.Printf("Configured addons:\n\t%s\n", strings.Join(lstMsgs, "\n\t"))
+
 	case InstallCommand:
-
 		installAddonFn := func(a *addon.Addon) (err error) {
-			if !r.noSpin {
-				doneCh := make(chan *runStatus)
+			pipeReader, pipeWriter := io.Pipe()
+			golog.SetOutput(pipeWriter)
+			buf := make([]byte, 1<<15)
+			var bufStr string
 
-				// Redirect stderr while we're spinning and filter out "proto: X"
-				// log spam (restore stderr on exit).
-				oldErr := os.Stderr
-				r, w, err := os.Pipe()
-				if err != nil {
-					return fmt.Errorf("can't create pipe2 for stderr redirect: %v", err)
+			// Remove log spam from third-party libs.
+			appendFilterBufStr := func(n int) {
+				bufStr += string(buf[:n])
+				lines := strings.Split(bufStr, "\n")
+				if len(lines) == 1 {
+					return
 				}
-				os.Stderr = w
-
-				defer func() {
-					// Restor stderr and close pipe.
-					os.Stderr = oldErr
-					w.Close()
-
-					sc := bufio.NewScanner(r)
-					s := &runStatus{err: err, doneCh: make(chan struct{})}
-					for sc.Scan() {
-						if strings.Contains(sc.Text(), "proto: ") {
-							continue
-						}
-						s.msgs = append(s.msgs, sc.Text())
+				// Prints all lines but the last line.
+				for i := 0; i < len(lines)-1; i++ {
+					line := lines[i]
+					if strings.Contains(line, "proto: ") || line == "" {
+						continue
 					}
-
-					doneCh <- s
-					<-s.doneCh
-				}()
-
-				go spinMsg(a.Name, doneCh)
+					fmt.Println(line)
+				}
+				// Since the last line might be incomplete, keep it until
+				// we see a newline.
+				bufStr = lines[len(lines)-1]
 			}
-			return a.Install(ctx)
+			go func() {
+				for {
+					n, err := pipeReader.Read(buf)
+					if err != nil {
+						if err == io.EOF {
+							appendFilterBufStr(n)
+							break
+						}
+						log.Errorf("error while reading from filtering pipe: %v", err)
+						break
+					}
+					appendFilterBufStr(n)
+					time.Sleep(100 * time.Millisecond)
+				}
+			}()
+
+			defer func() {
+				// Restore go log output and close pipe.
+				golog.SetOutput(os.Stderr)
+				pipeWriter.Close()
+			}()
+
+			if r.noSpin {
+				return a.Install(ctx)
+			}
+
+			errCh := make(chan error)
+			go spinMsg(a.Name, errCh)
+			err = a.Install(ctx)
+			errCh <- err
+			return err
 		}
 
 		if r.dryrun {
@@ -277,6 +289,7 @@ func (r *runtime) runCommand(ctx context.Context, cmd Command, addons []*addon.A
 		}
 
 		fmt.Printf("Rollout [%v] is live!\n", rollout.ID)
+
 	case RemoveCommand:
 		return runUntilErr(addons, func(a *addon.Addon) error {
 			return a.Remove(ctx)

--- a/pkg/util/filter_file.go
+++ b/pkg/util/filter_file.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/pkg/util/filter_file_test.go
+++ b/pkg/util/filter_file_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/pkg/util/strings_flag.go
+++ b/pkg/util/strings_flag.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (


### PR DESCRIPTION
Update: this PR now redirect stdlog to verbose glog instead of filtering through pipe. Also, I added the license preamble to files without it.

Original Description:
Some third-party lib that we use would write to stderr (using Go's standard `log` package)
```
I0318 18:23:41.979510   33487 clone.go:234] proto: don't know how to copy 0
```
or 
```
I0318 18:23:24.030427   33487 properties.go:196] proto: tag has too few fields: "-"
```
and is very distracting. 

Before this PR, Isopod does filter these log spam in actual addon install but not in dryrun. Prior implementation also has to wait until addon installation is complete before filtering the captured log. In this PR, such filtering/editing is done in streams and works for both dry run and actual install.  