### PR TITLE
Implement deletaion and recreation of immutable resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ golang-docker-base-image: &golang-docker-base-image
 
 linter-image: &linter-image
   docker:
-    - image: golangci/golangci-lint:v1.17
+    - image: golangci/golangci-lint:v1.24.0
 
 jobs:
   build:

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ var (
 	addonRegex         = flag.String("match_addons", "", "Filters configured addons based on provided regex.")
 	isopodCtx          = flag.String("context", "", "Comma-separated list of `foo=bar' context parameters passed to the clusters Starlark function.")
 	dryRun             = flag.Bool("dry_run", false, "Print intended actions but don't mutate anything.")
+	force              = flag.Bool("force", false, "Delete and recreate immutable resources without confirmation.")
 	svcAcctKeyFile     = flag.String("sa_key", "", "Path to the service account json file.")
 	noSpin             = flag.Bool("nospin", false, "Disables command line status spinner.")
 	kubeDiff           = flag.Bool("kube_diff", false, "Print diff against live Kubernetes objects.")
@@ -103,6 +104,7 @@ func buildClustersRuntime(mainFile string) runtime.Runtime {
 		UserAgent:         "Isopod/" + version,
 		KubeConfigPath:    *kubeconfig,
 		DryRun:            *dryRun,
+		Force:             *force,
 	})
 	if err != nil {
 		log.Exitf("Failed to initialize clusters runtime: %v", err)
@@ -157,6 +159,7 @@ func buildAddonsRuntime(kubeC *rest.Config, mainFile string) (runtime.Runtime, e
 		KubeConfigPath:    *kubeconfig,
 		Store:             st,
 		DryRun:            *dryRun,
+		Force:             *force,
 	}, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize addons runtime: %v", err)

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -60,9 +60,7 @@ func NewAbstractKubeVendor(typeStr string, requiredFields []string, kwargs []sta
 	for _, kwarg := range kwargs {
 		k := string(kwarg[0].(starlark.String))
 		v := kwarg[1]
-		if _, ok := required[k]; ok {
-			delete(required, k)
-		}
+		delete(required, k)
 		if err := kubeVendor.SetField(k, v); err != nil {
 			return nil, fmt.Errorf("<%s> cannot process field `%v=%v`", typeStr, k, v)
 		}

--- a/pkg/kube/kube_fake.go
+++ b/pkg/kube/kube_fake.go
@@ -389,7 +389,8 @@ func fakeDiscovery() discovery.DiscoveryInterface {
 }
 
 // NewFake returns a new fake kube module for testing.
-func NewFake() (m starlark.HasAttrs, closeFn func(), err error) {
+// It takes a bool attribute to determine if the starkalrk.HasAttrs object should forcefully update resources
+func NewFake(force bool) (m starlark.HasAttrs, closeFn func(), err error) {
 	// Create a fake API store with some endpoints pre-populated
 	cm := core.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -432,6 +433,7 @@ func NewFake() (m starlark.HasAttrs, closeFn func(), err error) {
 		dynamic.NewForConfigOrDie(rConf),
 		&http.Client{Transport: t},
 		false, /* dryRun */
+		force,
 		false, /* diff */
 		nil,   /* diffFilters */
 	)

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -46,6 +46,8 @@ import (
 	util "github.com/cruise-automation/isopod/pkg/testing"
 )
 
+const noneValue = "None"
+
 func statusWithDetails(group, kind, name, msg string) *metav1.Status {
 	return &metav1.Status{
 		TypeMeta: metav1.TypeMeta{
@@ -267,6 +269,7 @@ func addImports(t *testing.T, pkgs starlark.StringDict) {
 		"corev1":       "k8s.io.api.core.v1",
 		"ext":          "k8s.io.apiextensions_apiserver.pkg.apis.apiextensions.v1beta1",
 		"metav1":       "k8s.io.apimachinery.pkg.apis.meta.v1",
+		"rbacv1":       "k8s.io.api.rbac.v1",
 	} {
 		v, _, err := util.Eval(t.Name(), fmt.Sprintf("proto.package(%q)", group), nil, pkgs)
 		if err != nil {
@@ -446,32 +449,6 @@ func TestKubePackage(t *testing.T) {
 				Labels:      isopodLabels,
 				Annotations: map[string]string{ctxAnnotationKey: `{"env":"test"}`},
 			},
-		},
-		{
-			name: "Update Service (attempt to reset healthcheck port)",
-			expr: `kube.put(name='foo', namespace='bar', data=[corev1.Service(spec = corev1.ServiceSpec(healthCheckNodePort=41))])`,
-			gotObj: &corev1.Service{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Service",
-					APIVersion: "v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "foo",
-					ResourceVersion: "42",
-				},
-				Spec: corev1.ServiceSpec{
-					HealthCheckNodePort: 42,
-				},
-			},
-			wantURLs: urls("/api/v1/namespaces/bar/services/foo"),
-			wantPodMeta: &metav1.ObjectMeta{
-				Name:            "foo",
-				Namespace:       "bar",
-				Labels:          isopodLabels,
-				Annotations:     map[string]string{ctxAnnotationKey: `{"env":"test"}`},
-				ResourceVersion: "42",
-			},
-			wantErr: "<kube.put>: cannot update .spec.healthCheckNodePort to new value (want: 41, got: 42). requires resource recreation",
 		},
 		{
 			name: "Create Namespace",
@@ -704,7 +681,7 @@ func TestKubePackage(t *testing.T) {
 				t.Errorf("Unexpected error.\nWant:\n\t%s\nGot:\n\t%s", tc.wantErr, gotErr)
 			}
 			gotV := ""
-			if v != nil && v.String() != "None" {
+			if v != nil && v.String() != noneValue {
 				gotV = v.String()
 			}
 			if tc.wantResult != gotV {
@@ -718,7 +695,7 @@ func TestKubeExists(t *testing.T) {
 	pkgs := skycfg.UnstablePredeclaredModules(&protoRegistry{})
 	addImports(t, pkgs)
 
-	k, kClose, err := NewFake()
+	k, kClose, err := NewFake(false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -726,30 +703,15 @@ func TestKubeExists(t *testing.T) {
 
 	pkgs["kube"] = k
 
-	urls := func(url ...string) []string {
-		return url
-	}
 	for _, tc := range []struct {
 		name       string
 		expr       string
-		gotObj     apiruntime.Object
-		wantURLs   []string
 		wantErr    string
 		wantResult string
 	}{
 		{
-			name: "Pod doesn't exist",
-			expr: `kube.exists(pod='bar/foo')`,
-			gotObj: &corev1.Pod{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Pod",
-					APIVersion: "v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-			},
-			wantURLs:   urls("/api/v1/namespaces/bar/pods/foo"),
+			name:       "Pod doesn't exist",
+			expr:       `kube.exists(pod='bar/foo')`,
 			wantResult: `False`,
 		},
 	} {
@@ -765,7 +727,87 @@ func TestKubeExists(t *testing.T) {
 				t.Errorf("Unexpected error.\nWant:\n\t%s\nGot:\n\t%s", tc.wantErr, gotErr)
 			}
 			gotV := ""
-			if v != nil && v.String() != "None" {
+			if v != nil && v.String() != noneValue {
+				gotV = v.String()
+			}
+			if tc.wantResult != gotV {
+				t.Fatalf("Unexpected expression result.\nWant: %s\nGot: %s", tc.wantResult, gotV)
+			}
+		})
+	}
+}
+
+func TestErrImmutableRessource(t *testing.T) {
+	got := errImmutableRessource("testResource")
+	want := errors.New("cannot update testResource. Use -force to delete and recreate")
+	if want.Error() != got.Error() {
+		t.Errorf("Unexpected error.\nWant:\n\t%s\nGot:\n\t%s", want, got)
+	}
+}
+
+func TestUpdateImmutableResources(t *testing.T) {
+	pkgs := skycfg.UnstablePredeclaredModules(&protoRegistry{})
+	addImports(t, pkgs)
+
+	for _, tc := range []struct {
+		name         string
+		exprCreate   string
+		exprUpdate   string
+		forceEnabled bool
+		wantErr      string
+		wantResult   string
+	}{
+		{
+			name:       "Update ClusterRoleBinding",
+			exprCreate: `kube.put(name='foo', namespace='bar', api_group='rbac.authorization.k8s.io', data=[rbacv1.ClusterRoleBinding(roleRef=rbacv1.RoleRef(name="foo",kind="ClusterRole"))])`,
+			exprUpdate: `kube.put(name='foo', namespace='bar', api_group='rbac.authorization.k8s.io', data=[rbacv1.ClusterRoleBinding(roleRef=rbacv1.RoleRef(name="bar",kind="ClusterRole"))])`,
+			wantErr:    fmt.Sprintf("<kube.put>: %s", errImmutableRessource("roleRef").Error()),
+		},
+		{
+			name:         "Update ClusterRoleBinding force",
+			exprCreate:   `kube.put(name='foo', namespace='bar', api_group='rbac.authorization.k8s.io', data=[rbacv1.ClusterRoleBinding(roleRef=rbacv1.RoleRef(name="foo",kind="ClusterRole"))])`,
+			exprUpdate:   `kube.put(name='foo', namespace='bar', api_group='rbac.authorization.k8s.io', data=[rbacv1.ClusterRoleBinding(roleRef=rbacv1.RoleRef(name="bar",kind="ClusterRole"))])`,
+			forceEnabled: true,
+		},
+		{
+			name:       "Update ClusterRoleBinding",
+			exprCreate: `kube.put(name='foo', namespace='bar', data=[corev1.Service(spec = corev1.ServiceSpec(healthCheckNodePort=41))])`,
+			exprUpdate: `kube.put(name='foo', namespace='bar', data=[corev1.Service(spec = corev1.ServiceSpec(healthCheckNodePort=42))])`,
+			wantErr:    fmt.Sprintf("<kube.put>: %s", errImmutableRessource(".spec.healthCheckNodePort").Error()),
+		},
+		{
+			name:         "Update ClusterRoleBinding force",
+			exprCreate:   `kube.put(name='foo', namespace='bar', data=[corev1.Service(spec = corev1.ServiceSpec(healthCheckNodePort=41))])`,
+			exprUpdate:   `kube.put(name='foo', namespace='bar', data=[corev1.Service(spec = corev1.ServiceSpec(healthCheckNodePort=42))])`,
+			forceEnabled: true,
+		},
+	} {
+		sCtx := &addon.SkyCtx{Attrs: starlark.StringDict{"env": starlark.String("test")}}
+		t.Run(tc.name, func(t *testing.T) {
+
+			k, kClose, err := NewFake(tc.forceEnabled)
+			if err != nil {
+				t.Error(err)
+			}
+			defer kClose()
+
+			pkgs["kube"] = k
+
+			_, _, err = util.Eval("kube", tc.exprCreate, sCtx, pkgs)
+			if err != nil {
+				t.Error(err)
+			}
+			v, _, err := util.Eval("kube", tc.exprUpdate, sCtx, pkgs)
+
+			gotErr := ""
+			if err != nil {
+				gotErr = err.Error()
+			}
+			if tc.wantErr != gotErr {
+				t.Errorf("Unexpected error.\nWant:\n\t%s\nGot:\n\t%s", tc.wantErr, gotErr)
+			}
+			gotV := ""
+			if v != nil && v.String() != noneValue {
 				gotV = v.String()
 			}
 			if tc.wantResult != gotV {

--- a/pkg/kube/kube_yaml.go
+++ b/pkg/kube/kube_yaml.go
@@ -148,7 +148,7 @@ func (m *kubePackage) kubeUpdateYaml(ctx context.Context, r *apiResource, obj ru
 		return err
 	}
 	if found {
-		if err := mergeObjects(live, obj); err != nil {
+		if err := maybeRecreate(ctx, live, obj, m, r); err != nil {
 			return err
 		}
 	}

--- a/pkg/modules/struct_test.go
+++ b/pkg/modules/struct_test.go
@@ -15,7 +15,6 @@
 package modules
 
 import (
-	"fmt"
 	"testing"
 
 	"go.starlark.net/starlark"
@@ -30,12 +29,12 @@ func TestStruct(t *testing.T) {
 	}{
 		{
 			name:          "Simple struct",
-			expression:    fmt.Sprintf(`struct(foo="bar").to_json()`),
+			expression:    `struct(foo="bar").to_json()`,
 			expectedValue: `{"foo": "bar"}`,
 		},
 		{
 			name:          "Nested structs",
-			expression:    fmt.Sprintf(`struct(foo="bar", baz=struct(qux="bar")).to_json()`),
+			expression:    `struct(foo="bar", baz=struct(qux="bar")).to_json()`,
 			expectedValue: `{"baz": {"qux": "bar"}, "foo": "bar"}`,
 		},
 	} {

--- a/pkg/modules/uuid_test.go
+++ b/pkg/modules/uuid_test.go
@@ -87,12 +87,12 @@ func TestUUIDErrorCase(t *testing.T) {
 	}{
 		{
 			name:        "v3 needs exactly one argument",
-			expression:  fmt.Sprintf(`uuid.v3()`),
+			expression:  `uuid.v3()`,
 			expectedErr: errors.New("uuid.v3: got 0 arguments, want 1"),
 		},
 		{
 			name:        "v5 needs exactly one argument",
-			expression:  fmt.Sprintf(`uuid.v5()`),
+			expression:  `uuid.v5()`,
 			expectedErr: errors.New("uuid.v5: got 0 arguments, want 1"),
 		},
 	} {

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -44,6 +44,11 @@ type Config struct {
 	// live objects in cluster.
 	DryRun bool
 
+	// Force is true if the -force flag is set and will delete and recreate
+	// immutable resources without confirmation. By default Force is disabled
+	// and will error in case an immutable resource is being updated.
+	Force bool
+
 	// Store is the storage to keep all rollout status.
 	Store store.Store
 }

--- a/pkg/runtime/options.go
+++ b/pkg/runtime/options.go
@@ -51,6 +51,7 @@ type Option interface {
 
 type options struct {
 	dryRun  bool
+	force   bool
 	noSpin  bool
 	pkgs    starlark.StringDict
 	addonRe *regexp.Regexp
@@ -122,7 +123,7 @@ func WithKube(c *rest.Config, diff bool, diffFilters []string) Option {
 			return err
 		}
 
-		opts.pkgs["kube"] = kube.New(c.Host, dC, dynC, &http.Client{Transport: t}, opts.dryRun, diff, diffFilters)
+		opts.pkgs["kube"] = kube.New(c.Host, dC, dynC, &http.Client{Transport: t}, opts.dryRun, opts.force, diff, diffFilters)
 		pkgs := skycfg.UnstablePredeclaredModules(&protoRegistry{})
 		for name, pkg := range pkgs {
 			opts.pkgs[name] = pkg

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -82,11 +82,11 @@ type Runtime interface {
 type runtime struct {
 	Config
 	// filename string
-	globals        starlark.StringDict
-	pkgs           starlark.StringDict // Predeclared packages.
-	addonRe        *regexp.Regexp
-	store          store.Store
-	noSpin, dryrun bool
+	globals               starlark.StringDict
+	pkgs                  starlark.StringDict // Predeclared packages.
+	addonRe               *regexp.Regexp
+	store                 store.Store
+	noSpin, dryrun, force bool
 }
 
 func init() {
@@ -106,6 +106,7 @@ func New(c *Config, opts ...Option) (Runtime, error) {
 	}
 	options := &options{
 		dryRun: c.DryRun,
+		force:  c.Force,
 		pkgs: starlark.StringDict{
 			"error":  starlark.NewBuiltin("error", addon.ErrorFn),
 			"sleep":  starlark.NewBuiltin("sleep", addon.SleepFn),
@@ -132,6 +133,7 @@ func New(c *Config, opts ...Option) (Runtime, error) {
 		store:   c.Store,
 		noSpin:  options.noSpin,
 		dryrun:  options.dryRun,
+		force:   options.force,
 	}, nil
 }
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -54,6 +54,7 @@ func TestForEachCluster(t *testing.T) {
 		KubeConfigPath:    "kubeconfig",
 		Store:             storeStub{},
 		DryRun:            false,
+		Force:             false,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/runtime/unittest.go
+++ b/pkg/runtime/unittest.go
@@ -181,7 +181,7 @@ func exec(ctx context.Context, path string) (*result, error) {
 	startT := time.Now()
 
 	out := new(bytes.Buffer)
-	outFn := func(_ *starlark.Thread, msg string) { fmt.Fprintf(out, msg) }
+	outFn := func(_ *starlark.Thread, msg string) { fmt.Fprint(out, msg) }
 	thread := &starlark.Thread{
 		Print: outFn,
 		Load:  loader.NewModulesLoaderWithPredeclaredPkgs(filepath.Dir(path), pkgs).Load,

--- a/pkg/runtime/unittest.go
+++ b/pkg/runtime/unittest.go
@@ -152,7 +152,7 @@ func exec(ctx context.Context, path string) (*result, error) {
 	}
 	defer vClose()
 
-	k, kClose, err := kube.NewFake()
+	k, kClose, err := kube.NewFake(false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This implementation adds the feature of life cycle management for
immutable resources. When a request to update an immutable resource is
sent, we return an error. If the -force flag is set when running
the binary, the immutable resource is going to be deleted and recreated.

The dry run behavior reflects this update and returns an error if an
immutable resource should be updated or writes a warning if the -force
flag is enabled

Signed-off-by: Jonny Langefeld <jonny.langefeld@getcruise.com>