### PR TITLE
Add list returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,17 @@ cadmin = kube.get(clusterrbacsyncconfig="cluster-admin",
                   json=True)
 ```
 
+It is also possible to receive a list of kubernetes objects. They can be filtered
+as defined in the [API documentation](https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json).
+
+```python
+# Get all pods in namespace kube-system.
+pods = kube.get(pod="kube-system/")
+
+# Get all pods with label component=kube-apiserver
+pods = kube.get(pod="kube-system/?labelSelector=component=kube-apiserver")
+```
+
 #### `kube.exists`
 
 Checks whether a resource exists. If `wait` argument is set to duration (e.g

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -558,10 +558,10 @@ func parseHTTPResponse(r *http.Response) (obj runtime.Object, details string, er
 		return obj, fmt.Sprintf("%s%s `%s", d.Kind, d.Group, d.Name), nil
 	}
 
-	in, ok := obj.(metav1.Object)
-	if ok {
+	if in, ok := obj.(metav1.Object); ok {
 		return obj, fmt.Sprintf("%s%s `%s'", strings.ToLower(gvk.Kind), maybeCore(gvk.Group), maybeNamespaced(in.GetName(), in.GetNamespace())), nil
-	} else if _, ok := obj.(metav1.ListInterface); ok {
+	}
+	if _, ok := obj.(metav1.ListInterface); ok {
 		return obj, fmt.Sprintf("%s%s'", strings.ToLower(gvk.Kind), maybeCore(gvk.Group)), nil
 	}
 	return nil, "", fmt.Errorf("returned object does not implement `metav1.Object` or `metav1.ListInterface`: %v", obj)

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -559,11 +559,12 @@ func parseHTTPResponse(r *http.Response) (obj runtime.Object, details string, er
 	}
 
 	in, ok := obj.(metav1.Object)
-	if !ok {
-		return nil, "", fmt.Errorf("returned object does not implement `metav1.Object': %v", obj)
+	if ok {
+		return obj, fmt.Sprintf("%s%s `%s'", strings.ToLower(gvk.Kind), maybeCore(gvk.Group), maybeNamespaced(in.GetName(), in.GetNamespace())), nil
+	} else if _, ok := obj.(metav1.ListInterface); ok {
+		return obj, fmt.Sprintf("%s%s'", strings.ToLower(gvk.Kind), maybeCore(gvk.Group)), nil
 	}
-
-	return obj, fmt.Sprintf("%s%s `%s'", strings.ToLower(gvk.Kind), maybeCore(gvk.Group), maybeNamespaced(in.GetName(), in.GetNamespace())), nil
+	return nil, "", fmt.Errorf("returned object does not implement `metav1.Object` or `metav1.ListInterface`: %v", obj)
 }
 
 // kubePeek checks if object by url exists in Kubernetes.

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -408,6 +408,61 @@ func TestKubePackage(t *testing.T) {
 			wantResult: `map["apiVersion":"v1" "kind":"Pod" "metadata":map["creationTimestamp":None "name":"foo"] "spec":map["containers":None] "status":map[]]`,
 		},
 		{
+			name: "Get Pods as list",
+			expr: `kube.get(pod="bar/", json=True)`,
+			gotObj: &corev1.PodList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PodList",
+					APIVersion: "v1",
+				},
+				Items: []corev1.Pod{{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+					},
+				}},
+			},
+			wantURLs:   urls("/api/v1/namespaces/bar/pods"),
+			wantResult: `map["apiVersion":"v1" "items":[map["apiVersion":"v1" "kind":"Pod" "metadata":map["creationTimestamp":None "name":"foo"] "spec":map["containers":None] "status":map[]]] "kind":"PodList" "metadata":map[]]`,
+		},
+		{
+			name: "Get Pods as list with field selector: hit",
+			expr: `kube.get(pod="bar/?fieldSelector=metadata.name=foo", json=True)`,
+			gotObj: &corev1.PodList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PodList",
+					APIVersion: "v1",
+				},
+				Items: []corev1.Pod{{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+					},
+				}},
+			},
+			wantURLs:   urls("/api/v1/namespaces/bar/pods/"),
+			wantResult: `map["apiVersion":"v1" "items":[map["apiVersion":"v1" "kind":"Pod" "metadata":map["creationTimestamp":None "name":"foo"] "spec":map["containers":None] "status":map[]]] "kind":"PodList" "metadata":map[]]`,
+		},
+		{
+			name: "Get Pods as list with field selector: miss",
+			expr: `kube.get(pod="bar/?fieldSelector=metadata.name=bar", json=True)`,
+			gotObj: &corev1.PodList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PodList",
+					APIVersion: "v1",
+				},
+				Items: []corev1.Pod{},
+			},
+			wantURLs:   urls("/api/v1/namespaces/bar/pods/"),
+			wantResult: `map["apiVersion":"v1" "items":[] "kind":"PodList" "metadata":map[]]`,
+		},
+		{
 			name: "Update Service",
 			expr: `kube.put(name='foo', namespace='bar', data=[corev1.Service()])`,
 			gotObj: &corev1.Service{


### PR DESCRIPTION
This commit adds the ability to receive a list return in starlark, if the kubernetes api return a ListInterface.
This is useful for queries for a list of pods or deployments.

* tests written
* documentation update