### PR TITLE
Fix throttling requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ var (
 	vaultToken         = flag.String("vault_token", os.Getenv("VAULT_TOKEN"), "Vault token obtained during authentication.")
 	namespace          = flag.String("namespace", "default", "Kubernetes namespace to store metadata in.")
 	kubeconfig         = flag.String("kubeconfig", "", "Kubernetes client config path.")
+	qps                = flag.Int("qps", 100, "qps to configure the kubernetes RESTClient")
+	burst              = flag.Int("burst", 100, "the burst to configure the kubernetes RESTClient")
 	addonRegex         = flag.String("match_addons", "", "Filters configured addons based on provided regex.")
 	isopodCtx          = flag.String("context", "", "Comma-separated list of `foo=bar' context parameters passed to the clusters Starlark function.")
 	dryRun             = flag.Bool("dry_run", false, "Print intended actions but don't mutate anything.")
@@ -122,8 +124,8 @@ func buildAddonsRuntime(kubeC *rest.Config, mainFile string) (runtime.Runtime, e
 	}
 
 	// configure rate limiter
-	kubeC.QPS = float32(100)
-	kubeC.Burst = 100
+	kubeC.QPS = float32(*qps)
+	kubeC.Burst = *burst
 
 	cs, err := kubernetes.NewForConfig(kubeC)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -121,6 +121,10 @@ func buildAddonsRuntime(kubeC *rest.Config, mainFile string) (runtime.Runtime, e
 		vaultC.SetToken(*vaultToken)
 	}
 
+	// configure rate limiter
+	kubeC.QPS = float32(100)
+	kubeC.Burst = 100
+
 	cs, err := kubernetes.NewForConfig(kubeC)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Kubernetes clientset: %v", err)


### PR DESCRIPTION
Through the version updated introduced in https://github.com/cruise-automation/isopod/pull/39 we picked up an upgrade of the k8s/client-go library. Somwhere inbetween the [two versions of the change](https://github.com/cruise-automation/isopod/compare/v1.1.2...v1.1.3\#diff-37aff102a57d3d7b797f152915a6dc16L119-R109) k8s/client-go introduced an advanced rate limiter, that [assumes default qps of 5 and burst of 10](https://github.com/kubernetes/client-go/blob/master/rest/config.go\#L114-L120). For the requests that isopod makes these assumptions are too low and result in frequent throttling request errors.

This fix introduces higher defaults. To replicate the behavior of isopod v1.1.2, we could also swtich off rate limiting entirely by setting `kubeC.QPS = float32(-1)`, but now that we have a reate limiter available we might as well use it. Also since the k8s/client-go library assumes magic numbers as default, I think its fine if we just raise the defaults.

The effect of this test can be seen by running the following command once with a build from master and once with a build from this branch:
```
./bin/isopod --context cluster=minikube -kubeconfig=/Users/jonny.langefeld/.kube/config -dry_run install $(pwd)/examples/main.ipd
```