### PR TITLE
fix: app/v1 api group in kube fake

### DIFF
--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -788,20 +788,12 @@ func (m *kubePackage) kubeGet(ctx context.Context, r *apiResource, wait time.Dur
 		waitDone = time.After(wait)
 	}
 
-	obj, ok, err := m.kubePeek(ctx, url)
-	if err != nil {
-		return nil, err
-	}
-	if ok {
-		return obj, nil
-	}
-	if waitDone == nil {
-		return nil, ErrNotFound
-	}
-
+	// retryInterval is zero so no delay before the first poll.
+	var retryInterval time.Duration
 	for {
 		select {
-		case <-time.After(waitRetryInterval):
+		case <-time.After(retryInterval):
+			retryInterval = waitRetryInterval
 			obj, ok, err := m.kubePeek(ctx, url)
 			if err != nil {
 				return nil, err

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -362,7 +362,7 @@ func (m *kubePackage) kubeGetFn(t *starlark.Thread, b *starlark.Builtin, args st
 
 	// Optional api_group argument.
 	var apiGroup starlark.String
-	var wait time.Duration
+	var wait time.Duration = 30 * time.Second
 	var wantJSON bool
 	for _, kv := range kwargs[1:] {
 		switch string(kv[0].(starlark.String)) {
@@ -773,7 +773,7 @@ func (m *kubePackage) kubeDelete(_ context.Context, r *apiResource, foreground b
 }
 
 // waitRetryInterval is a duration between consecutive get retries.
-const waitRetryInterval = 1 * time.Second
+const waitRetryInterval = 500 * time.Millisecond
 
 var ErrNotFound = errors.New("not found")
 
@@ -783,32 +783,39 @@ var ErrNotFound = errors.New("not found")
 // tries once if wait is zero).
 func (m *kubePackage) kubeGet(ctx context.Context, r *apiResource, wait time.Duration) (runtime.Object, error) {
 	url := m.Master + r.PathWithName()
-	retryCh := make(chan interface{}, 1)
-	retryCh <- struct{}{} // Seed the channel so that we don't wait initially.
 	var waitDone <-chan time.Time
 	if wait != 0 {
 		waitDone = time.After(wait)
 	}
 
+	obj, ok, err := m.kubePeek(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return obj, nil
+	}
+	if waitDone == nil {
+		return nil, ErrNotFound
+	}
+
 	for {
 		select {
-		case retryCh <- time.After(waitRetryInterval):
-		case <-retryCh:
+		case <-time.After(waitRetryInterval):
 			obj, ok, err := m.kubePeek(ctx, url)
 			if err != nil {
 				return nil, err
 			}
-
 			if ok {
 				return obj, nil
 			}
-
 			if waitDone == nil {
 				return nil, ErrNotFound
 			}
 
 		case <-waitDone:
 			return nil, ErrNotFound
+
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}

--- a/pkg/kube/kube_fake.go
+++ b/pkg/kube/kube_fake.go
@@ -235,7 +235,6 @@ func fakeDiscovery() discovery.DiscoveryInterface {
 		{Name: "deployments", Namespaced: true, Kind: "Deployment"},
 		{Name: "controllerrevisions", Namespaced: true, Kind: "ControllerRevision"},
 		{Name: "daemonsets", Namespaced: true, Kind: "DaemonSet"},
-		{Name: "deployments", Namespaced: true, Kind: "Deployment"},
 		{Name: "replicasets", Namespaced: true, Kind: "ReplicaSet"},
 		{Name: "statefulsets", Namespaced: true, Kind: "StatefulSet"},
 	}
@@ -307,12 +306,9 @@ func fakeDiscovery() discovery.DiscoveryInterface {
 		{
 			GroupVersion: extensionsv1beta1.SchemeGroupVersion.String(),
 			APIResources: []metav1.APIResource{
-				{Name: "daemonsets", Namespaced: true, Kind: "DaemonSet"},
-				{Name: "deployments", Namespaced: true, Kind: "Deployment"},
 				{Name: "ingresses", Namespaced: true, Kind: "Ingress"},
 				{Name: "networkpolicies", Namespaced: true, Kind: "NetworkPolicy"},
 				{Name: "podsecuritypolicies", Kind: "PodSecurityPolicy"},
-				{Name: "replicasets", Namespaced: true, Kind: "ReplicaSet"},
 			},
 		},
 		{

--- a/pkg/runtime/unittest.go
+++ b/pkg/runtime/unittest.go
@@ -181,7 +181,7 @@ func exec(ctx context.Context, path string) (*result, error) {
 	startT := time.Now()
 
 	out := new(bytes.Buffer)
-	outFn := func(_ *starlark.Thread, msg string) { fmt.Fprint(out, msg) }
+	outFn := func(_ *starlark.Thread, msg string) { fmt.Println(msg) }
 	thread := &starlark.Thread{
 		Print: outFn,
 		Load:  loader.NewModulesLoaderWithPredeclaredPkgs(filepath.Dir(path), pkgs).Load,


### PR DESCRIPTION
Previously the Deployment resource is registered in the kube_fake's discovery client under two API groups: `apps/v1` and `extensions/v1beta1`. Apparently, this leads to non-deterministic GVK inference from RESTMapper (https://github.com/cruise-automation/isopod/blob/master/pkg/kube/api.go#L59-L74). 

The result is that `kube.get(deployment="ns/myapp")` maybe either of
```
GET /apis/apps/v1/namespaces/NS/deployments/myapp
```
or
```
GET /apis/extensions/v1beta1/namespaces/NS/deployments/myapp
```
but in the latter case, kube fake will return empty results (and fail the Starlark unit tests), because most users use the `k8s.io.api.apps.v1` proto package to build a Deployment.