### PR TITLE
Get names from proto tags instead of json tags

### DIFF
--- a/pkg/runtime/testdata/deployment.ipd
+++ b/pkg/runtime/testdata/deployment.ipd
@@ -3,6 +3,7 @@
 appsv1 = proto.package("k8s.io.api.apps.v1")
 metav1 = proto.package("k8s.io.apimachinery.pkg.apis.meta.v1")
 corev1 = proto.package("k8s.io.api.core.v1")
+utilintstr = proto.package("k8s.io.apimachinery.pkg.util.intstr")
 
 def install(ctx):
     kube.put(
@@ -33,6 +34,17 @@ def install(ctx):
                             ports=[corev1.ContainerPort(
                                 containerPort=80,
                             )],
+                            livenessProbe=corev1.Probe(
+                                handler=corev1.Handler(
+                                    httpGet=corev1.HTTPGetAction(
+                                        path="/healthz",
+                                        port=utilintstr.IntOrString(
+                                            intVal=8080,
+                                        ),
+                                        scheme="HTTPS",
+                                    ),
+                                ),
+                            ),
                         )],
                     )
                 ),

--- a/pkg/runtime/testdata/deployment.json
+++ b/pkg/runtime/testdata/deployment.json
@@ -27,7 +27,14 @@
                             {
                                 "containerPort": 80
                             }
-                        ]
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 8080,
+                                "scheme": "HTTPS"
+                            }
+                        }
                     }
                 ]
             }


### PR DESCRIPTION
Starlark structs go by the proto tags and not by json tags.
In fact, sometimes the json tags arent set, like in the example of liveness probe.

This fix gets the name from the proto tag to account for that

Fix #53