### PR TITLE
Testing support for PriorityClass and APIService resources

### DIFF
--- a/pkg/kube/kube_fake.go
+++ b/pkg/kube/kube_fake.go
@@ -56,6 +56,7 @@ import (
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiregistrationv1b1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 
 	isopod "github.com/cruise-automation/isopod/pkg"
 )
@@ -383,6 +384,12 @@ func fakeDiscovery() discovery.DiscoveryInterface {
 			GroupVersion: schedulingv1beta1.SchemeGroupVersion.String(),
 			APIResources: []metav1.APIResource{
 				{Name: "priorityclass", Kind: "PriorityClass"},
+			},
+		},
+		{
+			GroupVersion: apiregistrationv1b1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "apiservice", Kind: "APIService"},
 			},
 		},
 	}

--- a/pkg/kube/kube_fake.go
+++ b/pkg/kube/kube_fake.go
@@ -51,6 +51,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -376,6 +377,12 @@ func fakeDiscovery() discovery.DiscoveryInterface {
 			APIResources: []metav1.APIResource{
 				{Name: "validatingwebhookconfigurations", Kind: "ValidatingWebhookConfiguration"},
 				{Name: "mutatingwebhookconfigurations", Kind: "MutatingWebhookConfiguration"},
+			},
+		},
+		{
+			GroupVersion: schedulingv1beta1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "priorityclass", Kind: "PriorityClass"},
 			},
 		},
 	}


### PR DESCRIPTION
Error seen without this:
```
[2020-09-09T20:13:57Z] <kube.put>: failed to map resource: no matches for kind "APIService" in version 
"apiregistration.k8s.io/v1beta1"

[2020-09-09T20:13:58Z] <kube.put>: failed to map resource: no matches for kind "PriorityClass" in version 
"scheduling.k8s.io/v1beta1"
```