### PR TITLE
Recommendation for small code improvements

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -182,7 +182,7 @@ func (a *Addon) Install(ctx context.Context) error {
 		Load:  a.loader.Load,
 	}
 	if a.GetModule().Version() != "" {
-		sCtx.Attrs["addon_version"] = starlark.String(a.version)
+		sCtx.Attrs["addon_version"] = starlark.String(a.GetModule().Version())
 	}
 
 	thread.SetLocal(GoCtxKey, ctx)

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -140,24 +140,9 @@ func (a *Addon) LoadedModules() map[string]string {
 	return a.loader.GetLoaded()
 }
 
-// GetModuleVersion returns the version of loaded module
-func (a *Addon) GetModuleVersion(moduleName string) string {
-	return a.loader.GetLoadedModule(moduleName).Version()
-}
-
-// SetAddonVersion sets the version of the addon if its versioned
-func (a *Addon) SetAddonVersion(version string) {
-	a.version = version
-}
-
-// GetAddonVersion returns the version of the addon if its versioned
-func (a *Addon) GetAddonVersion() string {
-	return a.version
-}
-
-// GetAddonVersion returns the version of the addon if its versioned
-func (a *Addon) GetAddonFilepath() string {
-	return a.filepath
+// GetModule returns the version of loaded module
+func (a *Addon) GetModule() *loader.Module {
+	return a.loader.GetLoadedModule(a.filepath)
 }
 
 // Match is an optional matching hook. Returns true if addon matched the
@@ -196,7 +181,7 @@ func (a *Addon) Install(ctx context.Context) error {
 		Print: a.printFn,
 		Load:  a.loader.Load,
 	}
-	if a.version != "" {
+	if a.GetModule().Version() != "" {
 		sCtx.Attrs["addon_version"] = starlark.String(a.version)
 	}
 

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -139,6 +139,7 @@ func (l *modulesLoader) anchoredLoadFn(
 			return nil, fmt.Errorf("unknown file extension: %s", ext)
 		}
 
+		fileName := module
 		if strings.HasPrefix(module, "@") {
 			idx := strings.Index(module, "//")
 			if idx < 0 {
@@ -155,14 +156,14 @@ func (l *modulesLoader) anchoredLoadFn(
 			}
 			baseDir = dep.LocalDir()
 			version = dep.Version()
-			module = module[idx+2:] // suffix after double slash
+			fileName = module[idx+2:] // suffix after double slash
 		}
 
 		readerFn := NewFileReaderFactory(baseDir)
 		if mockReaderFn != nil {
 			readerFn = *mockReaderFn
 		}
-		r, closer, err := readerFn(module)
+		r, closer, err := readerFn(fileName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -139,7 +139,6 @@ func (l *modulesLoader) anchoredLoadFn(
 			return nil, fmt.Errorf("unknown file extension: %s", ext)
 		}
 
-		moduleNameKey := module
 		if strings.HasPrefix(module, "@") {
 			idx := strings.Index(module, "//")
 			if idx < 0 {
@@ -157,7 +156,6 @@ func (l *modulesLoader) anchoredLoadFn(
 			baseDir = dep.LocalDir()
 			version = dep.Version()
 			module = module[idx+2:] // suffix after double slash
-			moduleNameKey = moduleName
 		}
 
 		readerFn := NewFileReaderFactory(baseDir)
@@ -182,7 +180,7 @@ func (l *modulesLoader) anchoredLoadFn(
 		m = &Module{globals: globals, data: data, err: err, version: version}
 
 		// Update the cache.
-		l.loaded[moduleNameKey] = m
+		l.loaded[module] = m
 		return m.globals, m.err
 	}
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -200,16 +200,6 @@ func (r *runtime) runCommand(ctx context.Context, cmd Command, addons []*addon.A
 
 	case InstallCommand:
 		installAddonFn := func(a *addon.Addon) (err error) {
-			addonFilepath := a.GetAddonFilepath()
-			if strings.HasPrefix(addonFilepath, "@") {
-				idx := strings.Index(addonFilepath, "//")
-				if idx < 0 {
-					return fmt.Errorf("remote addon must contain double slash")
-				}
-				addonModuleName := addonFilepath[1:strings.Index(addonFilepath, "//")]
-				a.SetAddonVersion(a.GetModuleVersion(addonModuleName))
-				fmt.Printf("Addon %s has version %s\n", a.Name, a.GetAddonVersion())
-			}
 			if r.noSpin {
 				return a.Install(ctx)
 			}


### PR DESCRIPTION
This PR functions as a review for the `tagging_versioned_resources` branch and gives recommendations for code simplifications.

* it removes the duplicated parsing logic in the install command and just saves the addons with the full path in the cache. That way it can be referred to later using a.filepath