### PR TITLE
Fix load command inside a versioned addon

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -174,10 +174,10 @@ func (l *modulesLoader) anchoredLoadFn(
 		}
 
 		// Load and initialize the module in a new thread.
-		newBaseDir := filepath.Join(baseDir, filepath.Dir(module))
+		newBaseDir := filepath.Join(baseDir, filepath.Dir(fileName))
 		loadFn := l.anchoredLoadFn(newBaseDir, mockReaderFn)
 		thread := &starlark.Thread{Load: loadFn}
-		globals, err := starlark.ExecFile(thread, module, data, predeclared)
+		globals, err := starlark.ExecFile(thread, fileName, data, predeclared)
 		m = &Module{globals: globals, data: data, err: err, version: version}
 
 		// Update the cache.


### PR DESCRIPTION
- Nested load was broken in previous version tagging commit: https://github.com/cruise-automation/isopod/commit/f2c477679e32f05f9646f6d178d07e166f20435b#diff-7ebb5f642faf323b147d718da7f18576L129-R142
This change meant that these two vars which relied on the "modified" value of `module`
Were now using the "unmodified" value of `module` and running the addons threw this error:
```
E0910 16:04:54.169410   17535 main.go:274] addons run failed: <addon: my_addon> load failed: cannot load my_addon/my_addon.ipd: lstat /private/tmp/isopod-workspace/versioned_addon/1.0.0/@versioned_addon: no such file or directory
```