### PR TITLE
Cronjobs Batch V1Beta1 support

### DIFF
--- a/pkg/kube/kube_fake.go
+++ b/pkg/kube/kube_fake.go
@@ -357,7 +357,6 @@ func fakeDiscovery() discovery.DiscoveryInterface {
 			GroupVersion: batchv1b1.SchemeGroupVersion.String(),
 			APIResources: []metav1.APIResource{
 				{Name: "cronjobs", Namespaced: true, Kind: "CronJob"},
-				{Name: "jobs", Namespaced: true, Kind: "Job"},
 			},
 		},
 		{

--- a/pkg/kube/kube_fake.go
+++ b/pkg/kube/kube_fake.go
@@ -45,6 +45,7 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	batchv1b1 "k8s.io/api/batch/v1beta1"
 	csr "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -347,6 +348,13 @@ func fakeDiscovery() discovery.DiscoveryInterface {
 		},
 		{
 			GroupVersion: batchv1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "cronjobs", Namespaced: true, Kind: "CronJob"},
+				{Name: "jobs", Namespaced: true, Kind: "Job"},
+			},
+		},
+		{
+			GroupVersion: batchv1b1.SchemeGroupVersion.String(),
 			APIResources: []metav1.APIResource{
 				{Name: "cronjobs", Namespaced: true, Kind: "CronJob"},
 				{Name: "jobs", Namespaced: true, Kind: "Job"},


### PR DESCRIPTION
K8S 1.16 has support for CronJobs only in BatchV1Beta1 API Group:
https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#cronjob-v1beta1-batch