### PR TITLE
Fix CronJob under wrong namespace

### DIFF
--- a/pkg/kube/kube_fake.go
+++ b/pkg/kube/kube_fake.go
@@ -349,7 +349,6 @@ func fakeDiscovery() discovery.DiscoveryInterface {
 		{
 			GroupVersion: batchv1.SchemeGroupVersion.String(),
 			APIResources: []metav1.APIResource{
-				{Name: "cronjobs", Namespaced: true, Kind: "CronJob"},
 				{Name: "jobs", Namespaced: true, Kind: "Job"},
 			},
 		},


### PR DESCRIPTION
Fixes kube_fake unable to query for CronJob objects