### PR TITLE
Allow read of non-secret paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,20 +61,6 @@ var (
 
 func init() {
 	stdlog.SetFlags(stdlog.Lshortfile)
-	// If depsFile unset, and if $(pwd)/isopod.deps exists, update depsFile.
-	if *depsFile == "" {
-		workingDir, err := os.Getwd()
-		if err != nil {
-			log.Fatalf("Failed to get working dir: %v", err)
-		}
-		defaultDepsFilePath := filepath.Join(workingDir, dep.DepsFile)
-
-		if _, err = os.Stat(defaultDepsFilePath); os.IsNotExist(err) {
-			log.Info("Using no remote modules")
-			return
-		}
-		*depsFile = defaultDepsFilePath
-	}
 }
 
 func usageAndDie() {
@@ -218,6 +204,19 @@ func main() {
 		if err := dep.Load(*depsFile); err != nil {
 			log.Exitf("Failed to load deps file `%s': %v", *depsFile, err)
 		}
+	} else {
+		// If depsFile unset, and if $(pwd)/isopod.deps exists, update depsFile.
+		workingDir, err := os.Getwd()
+		if err != nil {
+			log.Fatalf("Failed to get working dir: %v", err)
+		}
+		defaultDepsFilePath := filepath.Join(workingDir, dep.DepsFile)
+
+		if _, err = os.Stat(defaultDepsFilePath); os.IsNotExist(err) {
+			log.Info("Using no remote modules")
+			return
+		}
+		*depsFile = defaultDepsFilePath
 	}
 
 	if cmd == runtime.TestCommand {

--- a/pkg/vault/vault_fake.go
+++ b/pkg/vault/vault_fake.go
@@ -54,6 +54,14 @@ func (fvlt *fakeVault) vaultFakeReadFn(t *starlark.Thread, b *starlark.Builtin, 
 		return nil, fmt.Errorf("<%v>: failed to parse args: %v", b.Name(), err)
 	}
 
+	if strings.HasPrefix(path, "sys") || strings.HasPrefix(path, "auth") {
+		_, err := fvlt.realClient.Logical().Read(path)
+		if err != nil {
+			return nil, fmt.Errorf("<%v>: request failed: %v", b.Name(), err)
+		}
+		return &fakeValues{}, nil
+	}
+
 	secretName := filepath.Base("/" + path)
 	parent := strings.ReplaceAll(path, "/"+secretName, "")
 	secretsListResp, err := fvlt.realClient.Logical().List(parent)
@@ -153,6 +161,14 @@ func (fvlt *fakeVault) vaultFakeExistFn(t *starlark.Thread, b *starlark.Builtin,
 	var path string
 	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &path); err != nil {
 		return nil, fmt.Errorf("<%v>: failed to parse args: %v", b.Name(), err)
+	}
+
+	if strings.HasPrefix(path, "sys") || strings.HasPrefix(path, "auth") {
+		_, err := fvlt.realClient.Logical().Read(path)
+		if err != nil {
+			return nil, fmt.Errorf("<%v>: request failed: %v", b.Name(), err)
+		}
+		return starlark.True, nil
 	}
 
 	secretName := filepath.Base("/" + path)


### PR DESCRIPTION
During a Dry Run we can't do a list on these paths:
```
E1006 10:19:23.320032   13387 main.go:274] addons run failed: `install' execution failed: failed addon installation: <addon: addon> run failed: <vault.read>: request failed: Error making API request.
URL: GET https://vault.abc.xyz:8200/v1/sys/?list=true
Code: 403. Errors:
* 1 error occurred:
        * permission denied

vault list sys
No value found at sys/
```

Also fixing flag.Parse error:
```
ERROR: logging before flag.Parse: I1021 14:45:20.344276   70669 main.go:73] Using no remote modules
```