### PR TITLE
Fix error in default deps func

### DIFF
--- a/main.go
+++ b/main.go
@@ -214,7 +214,6 @@ func main() {
 
 		if _, err = os.Stat(defaultDepsFilePath); os.IsNotExist(err) {
 			log.Info("Using no remote modules")
-			return
 		}
 		*depsFile = defaultDepsFilePath
 	}


### PR DESCRIPTION
Currently the return means the binary won't work unless `--deps` is specified