### PR TITLE
Print stacktrace for runtime errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/ory/dockertest v3.3.2+incompatible // indirect
 	github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/rs/xid v1.2.1
 	github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735 // indirect

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -27,6 +27,7 @@ import (
 	"go.starlark.net/starlark"
 
 	"github.com/cruise-automation/isopod/pkg/loader"
+	"github.com/cruise-automation/isopod/pkg/util"
 )
 
 // Addon implements single addons lifecycle hooks.
@@ -199,7 +200,7 @@ func (a *Addon) Install(ctx context.Context) error {
 
 	args := starlark.Tuple([]starlark.Value{sCtx})
 	_, err := starlark.Call(thread, fn, args, nil)
-	return err
+	return util.HumanReadableEvalError(err)
 }
 
 // Remove is called to remove the addon.
@@ -226,7 +227,7 @@ func (a *Addon) Remove(ctx context.Context) error {
 
 	args := starlark.Tuple([]starlark.Value{sCtx})
 	_, err := starlark.Call(thread, fn, args, nil)
-	return err
+	return util.HumanReadableEvalError(err)
 }
 
 // ErrorFn implements built-in for interrupting addon execution flow on error

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cruise-automation/isopod/pkg/loader"
 	"github.com/cruise-automation/isopod/pkg/modules"
 	"github.com/cruise-automation/isopod/pkg/store"
+	"github.com/cruise-automation/isopod/pkg/util"
 )
 
 const (
@@ -317,7 +318,8 @@ func (r *runtime) callStarlarkFunc(ctx context.Context, fnName string, args star
 	}
 	thread.SetLocal("context", ctx)
 
-	return starlark.Call(thread, entryFn, args, nil)
+	ret, err := starlark.Call(thread, entryFn, args, nil)
+	return ret, util.HumanReadableEvalError(err)
 }
 
 func goMapToSkyCtx(m map[string]string) *addon.SkyCtx {

--- a/pkg/runtime/unittest.go
+++ b/pkg/runtime/unittest.go
@@ -17,7 +17,6 @@ package runtime
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -26,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stripe/skycfg"
 	"go.starlark.net/starlark"
 
@@ -36,6 +36,7 @@ import (
 	"github.com/cruise-automation/isopod/pkg/kube"
 	"github.com/cruise-automation/isopod/pkg/loader"
 	"github.com/cruise-automation/isopod/pkg/modules"
+	"github.com/cruise-automation/isopod/pkg/util"
 	"github.com/cruise-automation/isopod/pkg/vault"
 )
 
@@ -232,8 +233,7 @@ func exec(ctx context.Context, path string) (*result, error) {
 					Runtime:    time.Since(startT),
 				}, nil
 			}
-
-			return nil, err
+			return nil, util.HumanReadableEvalError(err)
 		}
 	}
 

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -1,0 +1,30 @@
+// Copyright 2019 GM Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"github.com/pkg/errors"
+	"go.starlark.net/starlark"
+)
+
+// HumanReadableEvalError takes an error object returned by `starlark.Call` function,
+// convert the error message to include stacktrace.
+// If an error of any other type is passed in, it ignores and return the error object unmodified.
+func HumanReadableEvalError(err error) error {
+	if evalErr, ok := err.(*starlark.EvalError); ok {
+		return errors.New(evalErr.Backtrace())
+	}
+	return err
+}

--- a/pkg/util/errors_test.go
+++ b/pkg/util/errors_test.go
@@ -1,0 +1,83 @@
+// Copyright 2019 GM Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+func makeEvalErr() *starlark.EvalError {
+	file := "/file.ipd"
+	return &starlark.EvalError{
+		Msg: "invalid call of non-function (string)",
+		CallStack: starlark.CallStack{
+			{
+				Name: "foo",
+				Pos:  syntax.MakePosition(&file, 1, 1),
+			},
+			{
+				Name: "bar",
+				Pos:  syntax.MakePosition(&file, 1, 1),
+			},
+		},
+	}
+}
+
+func TestHumanReadableEvalError(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		err     error
+		wantErr error
+	}{
+		{
+			name: "normal",
+			err:  makeEvalErr(),
+			wantErr: fmt.Errorf(`Traceback (most recent call last):
+  /file.ipd:1:1: in foo
+  /file.ipd:1:1: in bar
+Error: invalid call of non-function (string)`),
+		},
+		{
+			name:    "nil error",
+			err:     nil,
+			wantErr: nil,
+		},
+		{
+			name:    "unrelated error",
+			err:     fmt.Errorf("foo"),
+			wantErr: fmt.Errorf("foo"),
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := HumanReadableEvalError(tc.err)
+			if gotErr == nil || tc.wantErr == nil {
+				if gotErr != tc.wantErr {
+					t.Errorf("Expect %s, got %s", tc.wantErr, gotErr)
+					return
+				}
+				return
+			}
+			if gotErr.Error() != tc.wantErr.Error() {
+				t.Errorf("Expect error message `%s'\ngot `%s'", tc.wantErr.Error(), gotErr.Error())
+				return
+			}
+		})
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -256,6 +256,7 @@ github.com/modern-go/reflect2
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/errors v0.8.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit


### PR DESCRIPTION
This PR makes CLI print starlark runtime error with full stacktrace.
Currnelty the CLI prints runtime errors like this, now way to tell where the error is from:
```
> isopod test /Users/mingfei.huang/workspace/paas-addon-common-bundle/addons/istio
invalid call of non-function (string)
FAIL	/Users/mingfei.huang/workspace/paas-addon-common-bundle/addons/istio/cert_update_test.ipd
```

With this PR:
```
> go run . test /Users/mingfei.huang/workspace/paas-addon-common-bundle/addons/istio
Traceback (most recent call last):
  /Users/mingfei.huang/workspace/paas-addon-common-bundle/addons/istio/cert_update_test.ipd:8:24: in test_install_cert_update
  ./cert_update.ipd:24:17: in install_cert_update
  ./cert_update.ipd:122:7: in install_cron
Error: invalid call of non-function (string)
FAIL	/Users/mingfei.huang/workspace/paas-addon-common-bundle/addons/istio/cert_update_test.ipd
```



