### PR TITLE
Encode version in api_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,10 +310,13 @@ kube.put(
 Supported args:
   + `name` - Name (`.metadata.name`) of the resource
   + `namespace` (Optional) - Namespace (`.metadata.namespace`) of the resource
-  + `api_group` (Optional) - API group (without version) of the resource. If
-     not provided, Isopod runtime will attempt to deduce the resource from
+  + `api_group` (Optional) - API group of the resource. If not provided,
+     Isopod runtime will attempt to deduce the resource from
      just Proto type name which is unreliable. It is recommended to set this
-     for all objects outside of `core` group.
+     for all objects outside of `core` group. Optionally, version can also be
+     specified after a `/`, example:
+     + `apiextensions.k8s.io` - specify the group only, version is implied from Proto or from runtime.
+     + `apiextensions.k8s.io/v1` - specify both group and version.
   + `subresource` (Optional) - A subresource specifier (e.g `/status`).
   + `data` - A list of Protobuf definitions of objects to be created.
 
@@ -328,8 +331,8 @@ Deletes object in Kubernetes.
 # non-namespaced resources).
 kube.delete(deployment="default/nginx")
 # api_group can optionally be provided to remove ambuguity (if multiple
-# resources by the same name exist in different API Groups).
-kube.delete(clusterrole="nginx", api_group = "rbac.authorization.k8s.io")
+# resources by the same name exist in different API Groups or different versions).
+kube.delete(clusterrole="nginx", api_group = "rbac.authorization.k8s.io/v1")
 ```
 
 ---

--- a/pkg/kube/api.go
+++ b/pkg/kube/api.go
@@ -65,7 +65,15 @@ func newResource(
 		return nil, err
 	}
 
-	partial := schema.GroupVersionResource{Group: apiGroup, Resource: resource}
+	// Guess version from apiGroup. Version is optionally passed in as postfix of apiGroup after a `/`.
+	version := ""
+	apiGroupSplitted := strings.Split(apiGroup, "/")
+	if len(apiGroupSplitted) > 1 {
+		version = apiGroupSplitted[len(apiGroupSplitted)-1]
+		apiGroup = strings.Join(apiGroupSplitted[:len(apiGroupSplitted)-1], "/")
+	}
+
+	partial := schema.GroupVersionResource{Group: apiGroup, Resource: resource, Version: version}
 	rMapper := restmapper.NewDiscoveryRESTMapper(gr)
 
 	gvk, err := rMapper.KindFor(partial)

--- a/pkg/kube/api_test.go
+++ b/pkg/kube/api_test.go
@@ -1,0 +1,154 @@
+// Copyright 2019 GM Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestNewResource(t *testing.T) {
+	for _, tc := range []struct {
+		testName string
+
+		name        string
+		namespace   string
+		apiGroup    string
+		resource    string
+		subresource string
+
+		wantResource *apiResource
+		wantErr      string
+	}{
+		{
+			testName:    "apiGroup omitted",
+			name:        "test-pod",
+			namespace:   "ns",
+			apiGroup:    "",
+			resource:    "pod",
+			subresource: "",
+
+			wantResource: &apiResource{
+				GVK: schema.GroupVersionKind{
+					Group:   "",
+					Version: "v1",
+					Kind:    "Pod",
+				},
+				Name:        "test-pod",
+				Namespace:   "ns",
+				Resource:    "pods",
+				Subresource: "",
+			},
+		},
+		{
+			testName:    "apiGroup included",
+			name:        "test-rs",
+			namespace:   "ns",
+			apiGroup:    "apps",
+			resource:    "replicaset",
+			subresource: "",
+
+			wantResource: &apiResource{
+				GVK: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "ReplicaSet",
+				},
+				Name:        "test-rs",
+				Namespace:   "ns",
+				Resource:    "replicasets",
+				Subresource: "",
+			},
+		},
+		{
+			testName:    "version included 1",
+			name:        "test-crd",
+			namespace:   "",
+			apiGroup:    "apiextensions.k8s.io/v1",
+			resource:    "customresourcedefinition",
+			subresource: "",
+
+			wantResource: &apiResource{
+				GVK: schema.GroupVersionKind{
+					Group:   "apiextensions.k8s.io",
+					Version: "v1",
+					Kind:    "CustomResourceDefinition",
+				},
+				Name:        "test-crd",
+				Namespace:   "",
+				Resource:    "customresourcedefinitions",
+				Subresource: "",
+			},
+		},
+		{
+			testName:    "version included 2",
+			name:        "test-crd",
+			namespace:   "",
+			apiGroup:    "apiextensions.k8s.io/v1beta1",
+			resource:    "customresourcedefinition",
+			subresource: "",
+
+			wantResource: &apiResource{
+				GVK: schema.GroupVersionKind{
+					Group:   "apiextensions.k8s.io",
+					Version: "v1beta1",
+					Kind:    "CustomResourceDefinition",
+				},
+				Name:        "test-crd",
+				Namespace:   "",
+				Resource:    "customresourcedefinitions",
+				Subresource: "",
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.testName, func(t *testing.T) {
+			resource, err := newResource(
+				fakeDiscovery(),
+				tc.name,
+				tc.namespace,
+				tc.apiGroup,
+				tc.resource,
+				tc.subresource,
+			)
+
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Errorf("Expect err `%s', got resource `%+v'", tc.wantErr, resource)
+					return
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("Expect err `%s', got err `%s'", tc.wantErr, err)
+					return
+				}
+			}
+			if err != nil {
+				t.Errorf("Expect resource `%+v', got err `%s'", resource, err)
+				return
+			}
+
+			if !reflect.DeepEqual(resource, tc.wantResource) {
+				r1, _ := json.MarshalIndent(tc.wantResource, "", "\t")
+				r2, _ := json.MarshalIndent(resource, "", "\t")
+				t.Errorf("Expect resource `%s', got resource `%s'", string(r1), string(r2))
+				return
+			}
+		})
+	}
+}

--- a/testdata/api_group_test.ipd
+++ b/testdata/api_group_test.ipd
@@ -1,0 +1,27 @@
+# vim: set syntax=python:
+
+# Copyright 2019 GM Cruise LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def test_api_group_versions(t):
+  kube.put_yaml(name="crd-v1", data=['{"apiVersion":"apiextensions.k8s.io/v1","kind":"CustomResourceDefinition","metadata":{"name":"crd-v1"}}'])
+  kube.put_yaml(name="crd-v1beta1", data=['{"apiVersion":"apiextensions.k8s.io/v1beta1","kind":"CustomResourceDefinition","metadata":{"name":"crd-v1beta1"}}'])
+
+  # Version matches, can get
+  assert(kube.exists(customresourcedefinition="crd-v1", api_group="apiextensions.k8s.io/v1", wait="0s") == True)
+  assert(kube.exists(customresourcedefinition="crd-v1beta1", api_group="apiextensions.k8s.io/v1beta1", wait="0s") == True)
+
+  # Version doesn't match, doesn't exist
+  assert(kube.exists(customresourcedefinition="crd-v1beta1", api_group="apiextensions.k8s.io/v1", wait="0s") == False)
+  assert(kube.exists(customresourcedefinition="crd-v1", api_group="apiextensions.k8s.io/v1beta1", wait="0s") == False)


### PR DESCRIPTION
This proposes to pass in api version as postfix of the `api_group` parameter for `kube.get` and `kube.delete`. It's used for identifying objects when more than 1 version of an API resource is registered to `kube_fake` at runtime.

Example usage:
```python
kube.get(customresourcedefinition="crd-v1", api_group="apiextensions.k8s.io/v1", wait="0s")
```

This does not break backward compatibility, `api_group` can still be used without version.

Added a tests:
* unit test for `newResource` function, for resource version resolution
* integration test `api_group_test.ipd`