### PR TITLE
Add Noop Store

### DIFF
--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -25,25 +25,6 @@ import (
 	"github.com/cruise-automation/isopod/pkg/store"
 )
 
-// storeStub implements Store interface for no-op store.
-type storeStub struct{}
-
-func (storeStub) CreateRollout() (*store.Rollout, error) { return &store.Rollout{}, nil }
-
-func (storeStub) PutAddonRun(id store.RolloutID, _ *store.AddonRun) (store.RunID, error) {
-	return "", nil
-}
-
-func (storeStub) CompleteRollout(id store.RolloutID) error { return nil }
-
-func (storeStub) GetLive() (*store.Rollout, bool, error) {
-	return nil, false, nil
-}
-
-func (storeStub) GetRollout(id store.RolloutID) (r *store.Rollout, found bool, err error) {
-	return nil, false, nil
-}
-
 func TestForEachCluster(t *testing.T) {
 	ctx := context.Background()
 
@@ -52,7 +33,7 @@ func TestForEachCluster(t *testing.T) {
 		GCPSvcAcctKeyFile: "some-sa-key",
 		UserAgent:         "Isopod",
 		KubeConfigPath:    "kubeconfig",
-		Store:             storeStub{},
+		Store:             store.NoopStore{},
 		DryRun:            false,
 		Force:             false,
 	})

--- a/pkg/store/noopstore.go
+++ b/pkg/store/noopstore.go
@@ -1,0 +1,28 @@
+package store
+
+// NoopStore implements Store interface for no-op store.
+// It does not store rollout and addon run information anywhere.
+type NoopStore struct{}
+
+// CreateRollout only returns a new empty Rollout.
+func (NoopStore) CreateRollout() (*Rollout, error) {
+	return &Rollout{}, nil
+}
+
+// PutAddonRun is a noop. It returns an empty string RunID.
+func (NoopStore) PutAddonRun(id RolloutID, _ *AddonRun) (RunID, error) {
+	return "", nil
+}
+
+// CompleteRollout is a noop.
+func (NoopStore) CompleteRollout(id RolloutID) error { return nil }
+
+// GetLive returns a nil Rollout and `false` for `found`.
+func (NoopStore) GetLive() (r *Rollout, found bool, err error) {
+	return nil, false, nil
+}
+
+// GetRollout returns a nil Rollout and `false` for `found`.
+func (NoopStore) GetRollout(id RolloutID) (r *Rollout, found bool, err error) {
+	return nil, false, nil
+}

--- a/pkg/store/noopstore.go
+++ b/pkg/store/noopstore.go
@@ -1,3 +1,17 @@
+// Copyright 2021 GM Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package store
 
 // NoopStore implements Store interface for no-op store.

--- a/pkg/store/noopstore_test.go
+++ b/pkg/store/noopstore_test.go
@@ -1,0 +1,42 @@
+package store
+
+import "testing"
+
+func checkErr(t *testing.T, err error, funcName string) {
+	if err != nil {
+		t.Errorf("%s returned a non-nil error.", funcName)
+	}
+}
+
+// TestNoopStore tests all methods in the Store interface for the NoopStore.
+// Since they are all noops, the testing is pretty simple.
+func TestNoopStore(t *testing.T) {
+	store := NoopStore{}
+
+	rollout, err := store.CreateRollout()
+	if rollout == nil {
+		t.Errorf("CreateRollout returned nil instead of empty rollout.")
+	}
+	checkErr(t, err, "CreateRollout")
+
+	runID, err := store.PutAddonRun("", nil)
+	if runID != "" {
+		t.Errorf("PutAddonRun returned a non-empty string")
+	}
+	checkErr(t, err, "PutAddonRun")
+
+	err = store.CompleteRollout("")
+	checkErr(t, err, "CompleteRollout")
+
+	_, found, err := store.GetLive()
+	if found {
+		t.Errorf("GetLive returned true for `found`. It should not find anything.")
+	}
+	checkErr(t, err, "GetLive")
+
+	_, found, err = store.GetRollout("")
+	if found {
+		t.Errorf("GetRollout returned true for `found`. It should not find anything.")
+	}
+	checkErr(t, err, "GetRollout")
+}

--- a/pkg/store/noopstore_test.go
+++ b/pkg/store/noopstore_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 GM Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package store
 
 import (

--- a/pkg/store/noopstore_test.go
+++ b/pkg/store/noopstore_test.go
@@ -1,6 +1,11 @@
 package store
 
-import "testing"
+import (
+	"testing"
+
+	// Required to add flags for tests to run properly.
+	_ "github.com/golang/glog"
+)
 
 func checkErr(t *testing.T, err error, funcName string) {
 	if err != nil {


### PR DESCRIPTION
This PR adds a `NoopStore` implementation of the `store.Store` interface. This lets isopod run without creating configmaps on every run in case the rollout information is stored entirely externally to isopod or is otherwise unneeded.

The original behaviour is preserved as the default, and an additional `--no_store` flag is added to swap to the NoopStore.